### PR TITLE
🌐 api: sign up endpoint

### DIFF
--- a/internal/auth/dto.go
+++ b/internal/auth/dto.go
@@ -1,0 +1,30 @@
+package auth
+
+type Role string
+
+const (
+	Admin    Role = "ADMIN"
+	Owner    Role = "OWNER"
+	Driver   Role = "DRIVER"
+	Customer Role = "CUSTOMER"
+)
+
+type SignUpRequest struct {
+	Name            string
+	Email           string
+	Bio             string
+	Phone           string
+	Password        string
+	ConfirmPassword string
+	Role            Role
+}
+
+type SignUpResponse struct {
+	ID   string
+	Role string
+}
+
+type SignInRequest struct {
+	Email    string
+	Password string
+}

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -1,6 +1,9 @@
 package auth
 
 import (
+	http_helper "food-delivery-app-server/pkg/http"
+	"food-delivery-app-server/pkg/utils"
+
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 )
@@ -16,15 +19,23 @@ func NewHandler(db *gorm.DB) *Handler {
 }
 
 func (h *Handler) SignUp(c *gin.Context) {
-
-	err := h.service.TestError()
+	req, err := http_helper.BindJSON[SignUpRequest](c)
 	if err != nil {
 		c.Error(err)
 		return
 	}
 
+	newUser, token, err := h.service.SignUp(*req)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	utils.SetCookie(c, token, 3600*5)
+
 	c.JSON(200, gin.H{
-		"message": "Sign Up Endpoint",
+		"message": "You have successfully registered an account",
+		"user":    newUser,
 	})
 }
 

--- a/internal/auth/repo.go
+++ b/internal/auth/repo.go
@@ -1,6 +1,10 @@
 package auth
 
-import "gorm.io/gorm"
+import (
+	"food-delivery-app-server/models"
+
+	"gorm.io/gorm"
+)
 
 type Repository struct {
 	db *gorm.DB
@@ -10,8 +14,21 @@ func NewRepository(db *gorm.DB) *Repository {
 	return &Repository{db: db}
 }
 
-func (r *Repository) FindUserByEmail() {
+var user models.User
+
+func (r *Repository) FindUserByEmail(email string) (*models.User, error) {
+	if err := r.db.Where("email = ?", email).First(&user).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &user, nil
 }
 
-func (r *Repository) CreateUser() {
+func (r *Repository) CreateUser(user *models.User) (*models.User, error) {
+	if err := r.db.Create(user).Error; err != nil {
+		return nil, err
+	}
+	return user, nil
 }

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -1,6 +1,12 @@
 package auth
 
-import "fmt"
+import (
+	"regexp"
+
+	"food-delivery-app-server/models"
+	appErr "food-delivery-app-server/pkg/errors"
+	"food-delivery-app-server/pkg/utils"
+)
 
 type Service struct {
 	repo *Repository
@@ -10,11 +16,64 @@ func NewService(repo *Repository) *Service {
 	return &Service{repo: repo}
 }
 
-func (s *Service) TestError() error {
-	return fmt.Errorf("failed to sign up, test error")
-}
+func (s *Service) SignUp(req SignUpRequest) (*SignUpResponse, string, error) {
+	if req.Email == "" || req.Password == "" || req.ConfirmPassword == "" ||
+		req.Name == "" || req.Bio == "" || req.Phone == "" {
+		return nil, "", appErr.NewBadRequest("Missing required fields", nil)
+	}
 
-func (s *Service) SignUp() {
+	validPhone := regexp.MustCompile(`^\+63[0-9]{10}$`)
+	if !validPhone.MatchString(req.Phone) {
+		return nil, "", appErr.NewBadRequest("Invalid phone number format. Use +63XXXXXXXXXX", nil)
+	}
+
+	if req.Password != req.ConfirmPassword {
+		return nil, "", appErr.NewBadRequest("Passwords do not match", nil)
+	}
+
+	existingUser, err := s.repo.FindUserByEmail(req.Email)
+	if err != nil {
+		return nil, "", appErr.NewBadRequest("Failed to verify if the email exists", err)
+	}
+
+	if existingUser != nil {
+		return nil, "", appErr.NewBadRequest("Email already exists", nil)
+	}
+
+	hashedPassword, err := utils.HashPassword(req.Password)
+	if err != nil {
+		return nil, "", appErr.NewInternal("Failed to hash the password", err)
+	}
+
+	userId := utils.GenerateUUID()
+
+	newUser := &models.User{
+		ID:             userId,
+		Name:           req.Name,
+		Email:          req.Email,
+		Password:       hashedPassword,
+		ProfilePicture: "https://fallback-image.com",
+		Bio:            req.Bio,
+		Phone:          req.Phone,
+		Role:           models.Role(req.Role),
+	}
+
+	createdUser, err := s.repo.CreateUser(newUser)
+	if err != nil {
+		return nil, "", appErr.NewInternal("Failed to create user at database", err)
+	}
+
+	token, err := utils.GenerateJWT(createdUser)
+	if err != nil {
+		return nil, "", appErr.NewInternal("Failed to generate token", err)
+	}
+
+	userResponse := SignUpResponse{
+		ID:   createdUser.ID.String(),
+		Role: string(createdUser.Role),
+	}
+
+	return &userResponse, token, nil
 }
 
 func (s *Service) SignIn() {

--- a/pkg/http/bindjson.go
+++ b/pkg/http/bindjson.go
@@ -1,0 +1,16 @@
+package http_helper
+
+import (
+	appErr "food-delivery-app-server/pkg/errors"
+
+	"github.com/gin-gonic/gin"
+)
+
+func BindJSON[T any](c *gin.Context) (*T, error) {
+	var req T
+	if err := c.ShouldBindJSON(&req); err != nil {
+		return nil, appErr.NewBadRequest("Invalid JSON request body", err)
+	}
+
+	return &req, nil
+}


### PR DESCRIPTION
Added the sign up endpoint via clean architecture principle (separation of concerns at the handler, service, & repository layer)

**🫳Handler Layer**
Tasks of the handler layer includes:
- Binding JSON from the request body using Gin
- Connecting to the service layer to handle service layer logic
- Setting a cookie session once the user was created
- Providing a successful response json

**📡Service Layer**
Request Body Validation Task (Business Logic):
- Check for missing request body fields
- Validate Phone Format (Using +63 country code only, Philippines)
- Verifies that `password` & `confirmPassword` match
- Checks if the email already exists in the database

Additional tasks of service layer:
- Hash password securely
- Generate user UUID
- Handle errors on each validation & use of utility functions
- Prepare request body to be passed into the repository layer
- Filter out response to prevent exposure of sensitive data

**💽 Repository Layer**
Database operations include:
- Find user by email (for existing user validation)
- Create a user 