### PR TITLE
🌐 api: sign in endpoint

### DIFF
--- a/internal/auth/dto.go
+++ b/internal/auth/dto.go
@@ -19,7 +19,7 @@ type SignUpRequest struct {
 	Role            Role
 }
 
-type SignUpResponse struct {
+type JWTAuthResponse struct {
 	ID   string
 	Role string
 }

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -40,8 +40,23 @@ func (h *Handler) SignUp(c *gin.Context) {
 }
 
 func (h *Handler) SignIn(c *gin.Context) {
+	req, err := http_helper.BindJSON[SignInRequest](c)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	user, token, err := h.service.SignIn(*req)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	utils.SetCookie(c, token, 3600*5)
+
 	c.JSON(200, gin.H{
-		"message": "Sign In Endpoint",
+		"message": "Signed In Successfully",
+		"user":    user,
 	})
 }
 


### PR DESCRIPTION
Added the sign in endpoint via clean architecture principle (separation of concerns at the handler, service, & repository layer)

**🫳Handler Layer**
- Binding JSON from the request body using Gin
- Connecting to the service layer to handle service layer logic
- Setting a cookie session once the user was created
- Providing a successful response json

**📡Service Layer**
- Check for missing request body fields
- Check for existing user by email
- Validate the password with the saved hashed password `bcrypt`
- Generate a jsonwebtoken
- Filter out response to prevent exposure of sensitive data

_No changes at the repository layer_