### PR TITLE
🧹 chore: refactor to separate oauth signin & signup

### DIFF
--- a/infrastructure/routes.go
+++ b/infrastructure/routes.go
@@ -18,7 +18,8 @@ func RegisterRoutes(r *gin.Engine) {
 	{
 		authGroup.POST("/signup", authHandler.SignUp)
 		authGroup.POST("/signin", authHandler.SignIn)
-		authGroup.POST("/oauth/:provider", authHandler.OAuth)
+		authGroup.POST("/oauth-signup/:provider", authHandler.OAuthSignUp)
+		authGroup.POST("/oauth-signin/:provider", authHandler.OAuthSignIn)
 		authGroup.POST("/send-otp", authHandler.SendOTP)
 		authGroup.POST("/verify-otp", authHandler.VerifyOTP)
 		authGroup.POST("/signout", authHandler.SignOut)

--- a/internal/auth/dto.go
+++ b/internal/auth/dto.go
@@ -37,32 +37,6 @@ type OAuthRequest struct {
 	AccessToken string `json:"accessToken"`
 }
 
-type GoogleResponseData struct {
-	Email      string `json:"email"`
-	GivenName  string `json:"given_name"`
-	FamilyName string `json:"family_name"`
-	Picture    string `json:"picture"`
-}
-
-type FacebookResponseData struct {
-	Email     string `json:"email"`
-	FirstName string `json:"first_name"`
-	LastName  string `json:"last_name"`
-	Picture   struct {
-		Data struct {
-			URL string `json:"url"`
-		} `json:"data"`
-	} `json:"picture"`
-}
-
-type UserInfo struct {
-	Email          string
-	FirstName      string
-	LastName       string
-	ProfilePicture string
-	Provider       string
-}
-
 // Send and Validate Phone OTP
 type SendOTPRequest struct {
 	StateID string `json:"stateId"`

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -62,7 +62,7 @@ func (h *Handler) SignIn(c *gin.Context) {
 	})
 }
 
-func (h *Handler) OAuth(c *gin.Context) {
+func (h *Handler) OAuthSignUp(c *gin.Context) {
 	provider := c.Param("provider")
 	req, err := http_helper.BindJSON[OAuthRequest](c)
 	if err != nil {
@@ -70,7 +70,7 @@ func (h *Handler) OAuth(c *gin.Context) {
 		return
 	}
 
-	stateID, err := h.service.OAuth(*req, provider)
+	stateID, err := h.service.OAuthSignUp(*req, provider)
 	if err != nil {
 		c.Error(err)
 		return
@@ -79,6 +79,28 @@ func (h *Handler) OAuth(c *gin.Context) {
 	c.JSON(200, gin.H{
 		"stateId": stateID,
 		"message": fmt.Sprintf("OAuth with %s succeeded; please verify phone next.", provider),
+	})
+}
+
+func (h *Handler) OAuthSignIn(c *gin.Context) {
+	provider := c.Param("provider")
+	req, err := http_helper.BindJSON[OAuthRequest](c)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	user, token, err := h.service.OAuthSignIn(*req, provider)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	utils.SetCookie(c, token, 3600*5)
+
+	c.JSON(200, gin.H{
+		"message": "You have successfully signed in",
+		"user":    user,
 	})
 }
 

--- a/internal/auth/repo.go
+++ b/internal/auth/repo.go
@@ -39,3 +39,14 @@ func (r *Repository) CreateAddress(address *models.Address) (*models.Address, er
 	}
 	return address, nil
 }
+
+func (r *Repository) FindFacebookUserByProfilePicturePrefix(string) (*models.User, error) {
+	prefix := "https://platform-lookaside.fbsbx.com"
+	if err := r.db.Where("profile_picture LIKE ? AND provider = ?", prefix+"%", "facebook").First(&user).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &user, nil
+}

--- a/pkg/oauth/verify_token.go
+++ b/pkg/oauth/verify_token.go
@@ -1,0 +1,77 @@
+package oauth
+
+import (
+	"encoding/json"
+	"net/http"
+
+	appErr "food-delivery-app-server/pkg/errors"
+)
+
+type GoogleResponseData struct {
+	Email      string `json:"email"`
+	GivenName  string `json:"given_name"`
+	FamilyName string `json:"family_name"`
+	Picture    string `json:"picture"`
+}
+
+type FacebookResponseData struct {
+	Email     string `json:"email"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+	Picture   struct {
+		Data struct {
+			URL string `json:"url"`
+		} `json:"data"`
+	} `json:"picture"`
+}
+
+type UserInfo struct {
+	Email          string
+	FirstName      string
+	LastName       string
+	ProfilePicture string
+	Provider       string
+}
+
+func VerifyGoogleToken(accessToken string) (*UserInfo, error) {
+	var data GoogleResponseData
+	resp, err := http.Get("https://www.googleapis.com/oauth2/v3/userinfo?access_token=" + accessToken)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return nil, appErr.NewInternal("failed to verify Google token", err)
+	}
+	defer resp.Body.Close()
+
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, err
+	}
+
+	return &UserInfo{
+		Email:          data.Email,
+		FirstName:      data.GivenName,
+		LastName:       data.FamilyName,
+		ProfilePicture: data.Picture,
+		Provider:       "google",
+	}, nil
+}
+
+func VerifyFacebookToken(accessToken string) (*UserInfo, error) {
+	var data FacebookResponseData
+	url := "https://graph.facebook.com/me?fields=id,first_name,last_name,email,picture&access_token=" + accessToken
+	resp, err := http.Get(url)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return nil, appErr.NewInternal("failed to verify Facebook token", err)
+	}
+	defer resp.Body.Close()
+
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, err
+	}
+
+	return &UserInfo{
+		Email:          data.Email,
+		FirstName:      data.FirstName,
+		LastName:       data.LastName,
+		ProfilePicture: data.Picture.Data.URL,
+		Provider:       "facebook",
+	}, nil
+}


### PR DESCRIPTION

✨ Implemented a separation between the OAuth sign up and sign in logic for better clarity and maintainability:

- Adds distinct endpoints: /oauth-signup/:provider for registration and /oauth-signin/:provider for login
- Refactors service and handler logic to clearly separate sign up (with OTP and user creation) from sign in (token verification and JWT issuance)
- Moves OAuth token verification and user info extraction to a new `verify_token.go` utility, centralizing third-party logic
- Adds a repository method for finding Facebook users by profile picture prefix
- Cleans up DTOs and removes redundant code