### PR TITLE
🧰 utility: textbee send sms

### DIFF
--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"log"
 	"strings"
 	"time"
 
@@ -224,8 +223,9 @@ func (s *Service) SendOTP(stateID, phone string) error {
 	utils.OtpStore.M[phone] = otp
 	utils.OtpStore.Unlock()
 
-	// Integrate the SMS provider here
-	log.Printf("OTP Code of the Food Delivery App %s was sent to %s", otp, phone)
+	if err := sms.SendOTPTextBee(phone, otp); err != nil {
+		return appErr.NewInternal("Failed to send OTP via SMS", err)
+	}
 
 	return nil
 }

--- a/pkg/sms/textbee.go
+++ b/pkg/sms/textbee.go
@@ -1,0 +1,60 @@
+package sms
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	appErr "food-delivery-app-server/pkg/errors"
+)
+
+type textBeeRequest struct {
+	Recipients []string `json:"recipients"`
+	Message    string   `json:"message"`
+}
+
+func SendOTPTextBee(phone, otp string) error {
+	apiKey := os.Getenv("TEXTBEE_API_KEY")
+	deviceID := os.Getenv("TEXTBEE_DEVICE_ID")
+
+	if apiKey == "" {
+		return appErr.NewInternal("TextBee API key not set", nil)
+	}
+	if deviceID == "" {
+		return appErr.NewInternal("TextBee Device ID not set", nil)
+	}
+
+	textBeeApi := fmt.Sprintf("https://api.textbee.dev/api/v1/gateway/devices/%s/send-sms", deviceID)
+
+	reqBody := textBeeRequest{
+		Recipients: []string{phone},
+		Message:    fmt.Sprintf("Good day! Your Food Delivery App OTP code for signing up is: %s", otp),
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return appErr.NewInternal("Failed to marshal SMS request body", err)
+	}
+
+	req, err := http.NewRequest("POST", textBeeApi, bytes.NewBuffer(body))
+	if err != nil {
+		return appErr.NewInternal("Failed to create SMS request", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", apiKey)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return appErr.NewInternal("Failed to send SMS request", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return appErr.NewInternal(fmt.Sprintf("Failed to send SMS: status %d", resp.StatusCode), nil)
+	}
+
+	return nil
+}


### PR DESCRIPTION
✨ Implements `textbee.go` utility with a SendOTPTextBee function that sends OTP messages using the TextBee API, following the documented request format.

- Integrates the new SMS utility into the SendOTP service method, replacing the previous log-based approach
- Handles API key and device ID configuration via environment variables
- Returns detailed internal errors if SMS sending fails

🚧Note:
Initial testing shows the API responds with status 201 (Created), indicating the request is accepted, but the actual SMS is not yet received on the target phone. Further testing and investigation with TextBee device setup and dashboard are ongoing to ensure end-to-end delivery.