### PR TITLE
🌐 api: delete menu item endpoint

### DIFF
--- a/internal/menuitem/owner.go
+++ b/internal/menuitem/owner.go
@@ -87,5 +87,19 @@ func (h *Handler) UpdateMenuItem(c *gin.Context) {
 }
 
 func (h *Handler) DeleteMenuItem(c *gin.Context) {
-	c.JSON(200, gin.H{"message": "Delete Menu Item Endpoint"})
+	menuItemId := c.Param("id")
+
+	userId, err := http_helper.ExtractUserIDFromContext(c)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	err = h.service.DeleteMenuItem(userId, menuItemId)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(200, gin.H{"message": "Food item has been deleted successfully"})
 }

--- a/internal/menuitem/repo.go
+++ b/internal/menuitem/repo.go
@@ -44,6 +44,23 @@ func (r *Repository) GetMenuItemByID(menuItemID uuid.UUID) (*models.MenuItem, er
 	return &menuItem, nil
 }
 
+func (r *Repository) GetRestaurantOwnerIDByID(restaurantID uuid.UUID) (uuid.UUID, error) {
+	var ownerIDStr string
+	err := r.db.
+		Model(&models.Restaurant{}).
+		Select("owner_id").
+		Where("id = ?", restaurantID).
+		Scan(&ownerIDStr).Error
+	if err != nil {
+		return uuid.Nil, err
+	}
+	ownerID, err := uuid.Parse(ownerIDStr)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	return ownerID, nil
+}
+
 func (r *Repository) GetMenuItemByRestaurant() {
 
 }
@@ -52,6 +69,9 @@ func (r *Repository) UpdateMenuItem(menuItem *models.MenuItem) error {
 	return r.db.Save(menuItem).Error
 }
 
-func (r *Repository) DeleteMenuItem() {
-
+func (r *Repository) DeleteMenuItem(menuId uuid.UUID) error {
+	if err := r.db.Delete(&models.MenuItem{}, "id = ?", menuId).Error; err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
✨ Implements the `DeleteMenuItem` endpoint for owners to delete menu items by ID.
- Implemented ownership validation to ensure only the restaurant owner can delete their menu items
- Refactored the repository with GetRestaurantOwnerIDByID and DeleteMenuItem methods for efficient authorization and deletion
- Integrated Cloudinary image deletion for menu items before removing them from the database
- Improved error handling and response messages for the delete operation