### PR TITLE
🔧 fix: order and payment relationship

### DIFF
--- a/models/order.go
+++ b/models/order.go
@@ -17,6 +17,7 @@ type Order struct {
 	PlacedAt        time.Time  `gorm:"autoCreateTime" json:"placedAt"`
 	UpdatedAt       time.Time  `gorm:"autoUpdateTime" json:"updatedAt"`
 
+	Payment    *Payment    `gorm:"foreignKey:OrderID" json:"payment,omitempty"`
 	Restaurant *Restaurant `gorm:"foreignKey:RestaurantID;references:ID;constraint:OnDelete:CASCADE" json:"restaurant,omitempty"`
 	Customer   *User       `gorm:"-" json:"customer,omitempty"`
 	Driver     *User       `gorm:"-" json:"driver,omitempty"`

--- a/models/payment.go
+++ b/models/payment.go
@@ -8,10 +8,13 @@ import (
 
 type Payment struct {
 	ID            uuid.UUID     `gorm:"primaryKey;type:uuid" json:"id"`
+	OrderID       uuid.UUID     `gorm:"type:uuid;index" json:"orderId"`
 	CustomerID    uuid.UUID     `gorm:"type:uuid;index" json:"customerId"`
 	Amount        float64       `gorm:"not null;" json:"amount"`
 	PaymentMethod string        `gorm:"type:varchar(20); not null;" json:"paymentMethod"`
 	PaidAt        time.Time     `gorm:"autoCreateTime" json:"paidAt"`
 	PaymentStatus PaymentStatus `gorm:"type:varchar(20); not null" json:"status"`
-	Customer      *User         `gorm:"foreignKey:CustomerID;references:ID;constraint:OnDelete:CASCADE" json:"customer,omitempty"`
+
+	Customer *User  `gorm:"foreignKey:CustomerID;references:ID;constraint:OnDelete:CASCADE" json:"customer,omitempty"`
+	Order    *Order `gorm:"foreignKey:OrderID; references:ID; constraint:OnDelete:CASCADE" json:"order,omitempty"`
 }


### PR DESCRIPTION

- Updated the Order and Payment models to establish a proper one-to-one relationship.
- Added the OrderID field to the Payment model and set up the corresponding foreign key and reference.
- Linked the Payment field in the Order model using the correct foreign key.
- Ensured that each order is now correctly associated with its payment record, improving data integrity and simplifying queries involving order payments