### PR TITLE
78 driver based endpoints template

### DIFF
--- a/infrastructure/routes/menu_items.go
+++ b/infrastructure/routes/menu_items.go
@@ -17,7 +17,7 @@ func RegisterMenuItemsRoutes(r *gin.Engine, DB *gorm.DB) {
 	{
 		owner.POST("/", middleware.UploadImageValidator("image"), menuItemHandler.CreateMenuItem)
 		owner.PUT("/:id", middleware.UploadImageValidator("image", true), menuItemHandler.UpdateMenuItem)
-		owner.DELETE("/", menuItemHandler.DeleteMenuItem)
+		owner.DELETE("/:id", menuItemHandler.DeleteMenuItem)
 	}
 
 	customer := r.Group("/", middleware.RequireRoles(models.Customer))

--- a/infrastructure/routes/order.go
+++ b/infrastructure/routes/order.go
@@ -13,6 +13,17 @@ func RegisterOrderRoutes(r *gin.Engine, DB *gorm.DB) {
 	orderHandler := order.NewHandler(DB)
 
 	order := r.Group("/orders", middleware.JWTAuthMiddleware())
+
+	allRoles := order.Group("/")
+	{
+		allRoles.GET("/:id") //not yet functional
+	}
+
+	custAndDriver := order.Group("/", middleware.RequireRoles(models.Customer, models.Driver))
+	{
+		custAndDriver.GET("/history") //not yet functional
+	}
+
 	owner := order.Group("/", middleware.RequireRoles(models.Owner))
 	{
 		owner.GET("/restaurant/:id", orderHandler.GetOrderByRestaurant) //not yet functional
@@ -21,8 +32,16 @@ func RegisterOrderRoutes(r *gin.Engine, DB *gorm.DB) {
 
 	customer := order.Group("/", middleware.RequireRoles(models.Customer))
 	{
-		customer.POST("/restaurant/:id", orderHandler.PlaceOrder)
-		customer.GET("/", orderHandler.GetAllPersonalOrders)
-		customer.PUT("/cancel/:id", orderHandler.CancelOrder)
+		customer.POST("/restaurant/:id", orderHandler.PlaceOrder) //not yet functional
+		customer.GET("/", orderHandler.GetAllPersonalOrders)      //not yet functional
+		customer.PUT("/:id/cancel", orderHandler.CancelOrder)     //not yet functional
+	}
+
+	driver := order.Group("/", middleware.RequireRoles(models.Driver))
+	{
+		driver.GET("/available")         //not yet functional
+		driver.PUT("/:id/accept")        //not yet functional
+		driver.GET("/assigned")          //not yet functional
+		driver.PUT("/:id/update-status") //not yet functional
 	}
 }

--- a/infrastructure/routes/order.go
+++ b/infrastructure/routes/order.go
@@ -16,18 +16,22 @@ func RegisterOrderRoutes(r *gin.Engine, DB *gorm.DB) {
 
 	allRoles := order.Group("/")
 	{
-		allRoles.GET("/:id") //not yet functional
+		allRoles.GET("/:id", orderHandler.GetOrderDetails) //not yet functional
+	}
+
+	ownerAndDriver := order.Group("/", middleware.RequireRoles(models.Owner, models.Driver))
+	{
+		ownerAndDriver.PUT("/:id", orderHandler.UpdateOrderStatus) //not yet functional
 	}
 
 	custAndDriver := order.Group("/", middleware.RequireRoles(models.Customer, models.Driver))
 	{
-		custAndDriver.GET("/history") //not yet functional
+		custAndDriver.GET("/history", orderHandler.GetOrderHistory) //not yet functional
 	}
 
 	owner := order.Group("/", middleware.RequireRoles(models.Owner))
 	{
 		owner.GET("/restaurant/:id", orderHandler.GetOrderByRestaurant) //not yet functional
-		owner.PUT("/:id", orderHandler.UpdateOrderStatus)               //not yet functional
 	}
 
 	customer := order.Group("/", middleware.RequireRoles(models.Customer))
@@ -39,9 +43,8 @@ func RegisterOrderRoutes(r *gin.Engine, DB *gorm.DB) {
 
 	driver := order.Group("/", middleware.RequireRoles(models.Driver))
 	{
-		driver.GET("/available")         //not yet functional
-		driver.PUT("/:id/accept")        //not yet functional
-		driver.GET("/assigned")          //not yet functional
-		driver.PUT("/:id/update-status") //not yet functional
+		driver.GET("/available", orderHandler.GetAvailableOrders) //not yet functional
+		driver.GET("/assigned", orderHandler.GetAssignedOrders)   //not yet functional
+		driver.PUT("/:id/status", orderHandler.UpdateOrderStatus) //not yet functional
 	}
 }

--- a/infrastructure/routes/restaurant.go
+++ b/infrastructure/routes/restaurant.go
@@ -16,14 +16,14 @@ func RegisterRestaurantRoutes(r *gin.Engine, DB *gorm.DB) {
 	owner := restaurant.Group("/", middleware.RequireRoles(models.Owner))
 	{
 		owner.POST("/", middleware.UploadImageValidator("image"), restaurantHandler.CreateRestaurant)
-		owner.GET("/", restaurantHandler.GetRestaurantByOwner)
+		owner.GET("/owner", restaurantHandler.GetRestaurantByOwner)
 		owner.PUT("/:id", middleware.UploadImageValidator("image", true), restaurantHandler.UpdateRestaurant)
 		owner.DELETE("/:id", restaurantHandler.DeleteRestaurant)
 	}
 
 	customer := restaurant.Group("/", middleware.RequireRoles(models.Customer))
 	{
-		customer.GET("/", restaurantHandler.GetAllRestaurants)                      //not yet functional
+		customer.GET("/customer", restaurantHandler.GetAllRestaurants)              //not yet functional
 		customer.GET("/:id/menu-items", restaurantHandler.GetMoreRestaurantDetails) //not yet functional
 	}
 }

--- a/infrastructure/routes/user.go
+++ b/infrastructure/routes/user.go
@@ -19,6 +19,7 @@ func RegisterUserRoutes(r *gin.Engine, DB *gorm.DB) {
 			userHandler.UpdateProfilePicture)
 		userGroup.DELETE("/delete", userHandler.DeleteUser)
 		userGroup.GET("/", middleware.RequireRoles(models.Admin), userHandler.GetAllUsers)
+		userGroup.GET("/driver/:id") //Not Yet Functional
 	}
 
 }

--- a/internal/order/driver.go
+++ b/internal/order/driver.go
@@ -1,0 +1,15 @@
+package order
+
+import "github.com/gin-gonic/gin"
+
+func (h *Handler) GetAvailableOrders(c *gin.Context) {
+	c.JSON(200, gin.H{"message": "Get Available Orders Endpoint"})
+}
+
+func (h *Handler) GetAssignedOrders(c *gin.Context) {
+	c.JSON(200, gin.H{"message": "Get Assigned Orders Endpoint"})
+}
+
+func (h *Handler) UpdateOrderByDriver(c *gin.Context) {
+	c.JSON(200, gin.H{"message": "Update Order Status"})
+}

--- a/internal/order/handler.go
+++ b/internal/order/handler.go
@@ -1,6 +1,9 @@
 package order
 
-import "gorm.io/gorm"
+import (
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
 
 type Handler struct {
 	service *Service
@@ -10,4 +13,19 @@ func NewHandler(db *gorm.DB) *Handler {
 	repo := NewRepository(db)
 	service := NewService(repo)
 	return &Handler{service: service}
+}
+
+// All Roles
+func (h *Handler) GetOrderDetails(c *gin.Context) {
+	c.JSON(200, gin.H{"message": "Get Order Details Endpoint"})
+}
+
+// Customer & Driver
+func (h *Handler) GetOrderHistory(c *gin.Context) {
+	c.JSON(200, gin.H{"message": "Get Order History Endpoint"})
+}
+
+// Owner & Driver
+func (h *Handler) UpdateOrderStatus(c *gin.Context) {
+	c.JSON(200, gin.H{"message": "Update Order Endpoint"})
 }

--- a/internal/order/owner.go
+++ b/internal/order/owner.go
@@ -2,10 +2,14 @@ package order
 
 import "github.com/gin-gonic/gin"
 
+func (h *Handler) AcceptOrderByOwner(c *gin.Context) {
+	c.JSON(200, gin.H{"message": "Accept Order By Owner Endpoint"})
+}
+
 func (h *Handler) GetOrderByRestaurant(c *gin.Context) {
 	c.JSON(200, gin.H{"message": "Get Order By Restaurant Endpoint"})
 }
 
-func (h *Handler) UpdateOrderStatus(c *gin.Context) {
+func (h *Handler) UpdateOrderByOwner(c *gin.Context) {
 	c.JSON(200, gin.H{"message": "Update Order Status Endpoint"})
 }

--- a/internal/order/service.go
+++ b/internal/order/service.go
@@ -12,6 +12,14 @@ func (s *Service) GetOrderByRestaurant() {
 
 }
 
-func (s *Service) UpdateOrderStatus() {
+func (s *Service) GetOrderDetails() {
+
+}
+
+func (s *Service) GetOrderHistory() {
+
+}
+
+func (s *Service) GetAvailableOrders() {
 
 }

--- a/models/enum.go
+++ b/models/enum.go
@@ -12,14 +12,16 @@ const (
 type Status string
 
 const (
-	Pending        Status = "PENDING"
-	Accepted       Status = "ACCEPTED"
-	Rejected       Status = "REJECTED"
-	ReadyForPickUp Status = "READY_FOR_PICKUP"
-	Assigned       Status = "ASSIGNED"
-	InTransit      Status = "IN_TRANSIT"
-	Delivered      Status = "DELIVERED"
-	Canceled       Status = "CANCELED"
+	Pending          Status = "PENDING"
+	AcceptedByOwner  Status = "ACCEPTED_BY_OWNER"
+	AcceptedByDriver Status = "ACCEPTED_BY_DRIVER"
+	RejectedByOwner  Status = "REJECTED_BY_OWNER"
+	RejectedByDriver Status = "REJECTED_BY_DRIVER"
+	ReadyForPickUp   Status = "READY_FOR_PICKUP"
+	Assigned         Status = "ASSIGNED"
+	InTransit        Status = "IN_TRANSIT"
+	Delivered        Status = "DELIVERED"
+	Canceled         Status = "ORDER_CANCELED"
 )
 
 type PaymentStatus string


### PR DESCRIPTION
 ✨To initialize the **routes, handler, and service layer** related to the role driver and modify other existing templates for clarity of role restrictions per route.

- Added initial customer and driver routes for orders, including handler and service stubs for driver-specific endpoints (available orders, assigned orders, update status).
- Refactored restaurant and order routes to avoid path conflicts and clarify role-based access (e.g., /owner, /customer subpaths).
- Updated menu item delete route to use /:id for RESTful consistency.
- Enhanced order status enum values for more granular tracking (e.g., AcceptedByOwner, AcceptedByDriver, RejectedByOwner, RejectedByDriver, ORDER_CANCELED).