### PR TITLE
86 refactor change in memory map to redis on oauth

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,6 +11,7 @@ func main() {
 	// add --migrate in running Go if it needs db migration
 	config.HandleMigrationFlag()
 
+	infrastructure.ConnectRedis()
 	infrastructure.ConnectDb()
 	infrastructure.RunGin()
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,11 @@ go 1.23.5
 require github.com/joho/godotenv v1.5.1
 
 require (
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+)
+
+require (
 	github.com/bytedance/sonic v1.11.6 // indirect
 	github.com/bytedance/sonic/loader v0.1.1 // indirect
 	github.com/cloudinary/cloudinary-go/v2 v2.10.1 // indirect
@@ -34,6 +39,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/redis/go-redis/v9 v9.11.0
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc
 github.com/bytedance/sonic v1.11.6/go.mod h1:LysEHSvpvDySVdC2f87zGWf6CIKJcAvqab1ZaiQtds4=
 github.com/bytedance/sonic/loader v0.1.1 h1:c+e5Pt1k/cy5wMveRDyk2X4B9hF4g7an8N3zCYjJFNM=
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudinary/cloudinary-go/v2 v2.10.1 h1:4qyuFW6vufjLPTtZBeuu1jVFszzVi4rSwf6kAz0U2EA=
 github.com/cloudinary/cloudinary-go/v2 v2.10.1/go.mod h1:ireC4gqVetsjVhYlwjUJwKTbZuWjEIynbR9zQTlqsvo=
 github.com/cloudwego/base64x v0.1.4 h1:jwCgWpFanWmN8xoIUHa2rtzmkd5J2plF/dnLS6Xd/0Y=
@@ -12,6 +14,8 @@ github.com/creasty/defaults v1.7.0 h1:eNdqZvc5B509z18lD8yc212CAqJNvfT1Jq6L8WowdB
 github.com/creasty/defaults v1.7.0/go.mod h1:iGzKe6pbEHnpMPtfDXZEr0NVxWnPTjb1bbDy08fPzYM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
@@ -65,6 +69,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/redis/go-redis/v9 v9.11.0 h1:E3S08Gl/nJNn5vkxd2i78wZxWAPNZgUNTp8WIJUAiIs=
+github.com/redis/go-redis/v9 v9.11.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/infrastructure/connect_redis.go
+++ b/infrastructure/connect_redis.go
@@ -1,0 +1,36 @@
+package infrastructure
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/redis/go-redis/v9"
+)
+
+var (
+	RedisClient *redis.Client
+	ctx         = context.Background()
+)
+
+func ConnectRedis() {
+	redisURL := os.Getenv("REDIS_URL")
+
+	if redisURL == "" {
+		log.Fatal("Environmental variable REDIS_URL does not exist")
+	}
+
+	opt, err := redis.ParseURL(redisURL)
+	if err != nil {
+		log.Fatalf("Failed to parse the REDIS_URL: %v", err)
+	}
+
+	RedisClient = redis.NewClient(opt)
+
+	_, err = RedisClient.Ping(ctx).Result()
+	if err != nil {
+		log.Fatalf("Failed to connect to the Redis Upstash: %v", err)
+	}
+
+	log.Printf("🍪 Connected successfully to Redis Client")
+}

--- a/infrastructure/gin_server.go
+++ b/infrastructure/gin_server.go
@@ -19,7 +19,7 @@ func RunGin() {
 
 	r.Use(middleware.ErrorHandler())
 
-	routes.RegisterRoutes(r, DB)
+	routes.RegisterRoutes(r, DB, RedisClient)
 
 	err := r.Run(":" + port)
 	if err != nil {

--- a/infrastructure/routes/auth.go
+++ b/infrastructure/routes/auth.go
@@ -2,13 +2,14 @@ package routes
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/redis/go-redis/v9"
 	"gorm.io/gorm"
 
 	"food-delivery-app-server/internal/auth"
 )
 
-func RegisterAuthRoutes(r *gin.Engine, DB *gorm.DB) {
-	authHandler := auth.NewHandler(DB)
+func RegisterAuthRoutes(r *gin.Engine, DB *gorm.DB, rdb *redis.Client) {
+	authHandler := auth.NewHandler(DB, rdb)
 
 	authGroup := r.Group("/auth")
 	{

--- a/infrastructure/routes/routes.go
+++ b/infrastructure/routes/routes.go
@@ -2,12 +2,13 @@ package routes
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/redis/go-redis/v9"
 	"gorm.io/gorm"
 )
 
-func RegisterRoutes(r *gin.Engine, DB *gorm.DB) {
+func RegisterRoutes(r *gin.Engine, DB *gorm.DB, rdb *redis.Client) {
 	// Baseline Feature Routes
-	RegisterAuthRoutes(r, DB)
+	RegisterAuthRoutes(r, DB, rdb)
 	RegisterUserRoutes(r, DB)
 	RegisterResetPasswordRoutes(r, DB)
 

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/gin-gonic/gin"
+	"github.com/redis/go-redis/v9"
 	"gorm.io/gorm"
 )
 
@@ -14,9 +15,9 @@ type Handler struct {
 	service *Service
 }
 
-func NewHandler(db *gorm.DB) *Handler {
+func NewHandler(db *gorm.DB, rdb *redis.Client) *Handler {
 	repo := NewRepository(db)
-	service := NewService(repo)
+	service := NewService(repo, rdb)
 	return &Handler{service: service}
 }
 

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"time"
 
@@ -11,6 +12,8 @@ import (
 	"food-delivery-app-server/pkg/oauth"
 	"food-delivery-app-server/pkg/sms"
 	"food-delivery-app-server/pkg/utils"
+
+	"github.com/redis/go-redis/v9"
 )
 
 var DefaultProfilePic string = "https://res.cloudinary.com/dowkytkyb/image/upload/v1750666850/default_profile_qbzide.png"
@@ -19,7 +22,7 @@ type Service struct {
 	repo *Repository
 }
 
-func NewService(repo *Repository) *Service {
+func NewService(repo *Repository, rdb *redis.Client) *Service {
 	return &Service{repo: repo}
 }
 
@@ -151,7 +154,7 @@ func (s *Service) OAuthSignUp(req OAuthRequest, provider string) (string, error)
 		return "", appErr.NewBadRequest("Failed to verify token", err)
 	}
 
-	stateID := utils.GenerateStateID(info)
+	stateID := utils.GenerateStateID(rdb, info)
 
 	return stateID, nil
 }
@@ -210,18 +213,16 @@ func (s *Service) SendOTP(stateID, phone string) error {
 		return appErr.NewBadRequest("Invalid phone number", err)
 	}
 
-	utils.OAuthTempStore.RLock()
-	data, ok := utils.OAuthTempStore.M[stateID]
-	utils.OAuthTempStore.RUnlock()
-	if !ok || time.Now().After(data.ExpiresAt) {
+	data, err := utils.GetOAuthTemp(rdb, stateID)
+	if err != nil || time.Now().After(data.ExpiresAt) {
 		return appErr.NewBadRequest("Invalid or Expired State ID", nil)
 	}
 
 	otp := utils.GenerateOTP()
 
-	utils.OtpStore.Lock()
-	utils.OtpStore.M[phone] = otp
-	utils.OtpStore.Unlock()
+	if err := utils.SetOTP(rdb, phone, otp, 5*time.Minute); err != nil {
+		return appErr.NewInternal("Failed to store OTP", err)
+	}
 
 	if err := sms.SendOTPTextBee(phone, otp); err != nil {
 		return appErr.NewInternal("Failed to send OTP via SMS", err)
@@ -239,23 +240,24 @@ func (s *Service) VerifyOTP(req VerifyOTPRequest) (*JWTAuthResponse, string, err
 		return nil, "", appErr.NewBadRequest("Invalid phone number", err)
 	}
 
-	utils.OtpStore.RLock()
-	expectedOTP, ok := utils.OtpStore.M[phone]
-	utils.OtpStore.RUnlock()
-	if !ok || expectedOTP != otp {
+	storedOTP, err := utils.GetOTP(rdb, phone)
+	if err != nil || storedOTP != otp {
 		return nil, "", appErr.NewBadRequest("Invalid or expired OTP", nil)
 	}
 
-	utils.OAuthTempStore.RLock()
-	oAuthData, ok := utils.OAuthTempStore.M[stateID]
-	utils.OAuthTempStore.RUnlock()
-	if !ok || time.Now().After(oAuthData.ExpiresAt) {
+	oAuthData, err := utils.GetOAuthTemp(rdb, stateID)
+	if err != nil || time.Now().After(oAuthData.ExpiresAt) {
 		return nil, "", appErr.NewBadRequest("Invalid or expired state ID", nil)
 	}
 
 	info, ok := oAuthData.Info.(*oauth.UserInfo)
 	if !ok {
-		return nil, "", appErr.NewInternal("Failed to parse OAuth user info", nil)
+		b, _ := json.Marshal(oAuthData.Info)
+		var userInfo oauth.UserInfo
+		if err := json.Unmarshal(b, &userInfo); err != nil {
+			return nil, "", appErr.NewInternal("Failed to parse OAuth user info", err)
+		}
+		info = &userInfo
 	}
 
 	userId := utils.GenerateUUID()
@@ -280,8 +282,6 @@ func (s *Service) VerifyOTP(req VerifyOTPRequest) (*JWTAuthResponse, string, err
 	if err != nil {
 		return nil, "", appErr.NewInternal("Failed to generate token", err)
 	}
-
-	utils.CleanMemory(phone, stateID)
 
 	userResponse := JWTAuthResponse{
 		ID:   createdUser.ID.String(),

--- a/pkg/utils/otp.go
+++ b/pkg/utils/otp.go
@@ -1,10 +1,14 @@
 package utils
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sync"
+
 	"time"
+
+	"github.com/redis/go-redis/v9"
 )
 
 type OAuthTempData struct {
@@ -12,37 +16,60 @@ type OAuthTempData struct {
 	ExpiresAt time.Time
 }
 
-var OtpStore = struct {
-	sync.RWMutex
-	M map[string]string
-}{M: make(map[string]string)}
-
-var OAuthTempStore = struct {
-	sync.RWMutex
-	M map[string]OAuthTempData
-}{M: make(map[string]OAuthTempData)}
-
 func GenerateOTP() string {
 	return fmt.Sprintf("%05d", rand.Intn(100000))
 }
 
-func GenerateStateID(info interface{}) string {
+// OTP only
+func SetOTP(rdb *redis.Client, phone, otp string, expiration time.Duration) error {
+	ctx := context.Background()
+	return rdb.Set(ctx, "otp:"+phone, otp, expiration).Err()
+}
+
+func GetOTP(rdb *redis.Client, phone string) (string, error) {
+	ctx := context.Background()
+	return rdb.Get(ctx, "otp:"+phone).Result()
+}
+
+func DeleteOTP(rdb *redis.Client, phone string) error {
+	ctx := context.Background()
+	return rdb.Del(ctx, "otp:"+phone).Err()
+}
+
+// OAuth Retrieved Data
+func SetOAuthTemp(rdb *redis.Client, stateID string, data OAuthTempData, expiration time.Duration) error {
+	ctx := context.Background()
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	return rdb.Set(ctx, "oauth"+stateID, b, expiration).Err()
+}
+
+func GetOAuthTemp(rdb *redis.Client, stateID string) (OAuthTempData, error) {
+	ctx := context.Background()
+	val, err := rdb.Get(ctx, "oauth"+stateID).Result()
+	if err != nil {
+		return OAuthTempData{}, err
+	}
+
+	var data OAuthTempData
+	err = json.Unmarshal([]byte(val), &data)
+	return data, err
+}
+
+func DeleteOAuthTemp(rdb *redis.Client, stateID string) error {
+	ctx := context.Background()
+	return rdb.Del(ctx, "oauth:"+stateID).Err()
+}
+
+func GenerateStateID(rdb *redis.Client, info interface{}) string {
 	stateID := GenerateUUIDStr()
-	OAuthTempStore.Lock()
-	OAuthTempStore.M[stateID] = OAuthTempData{
+	data := OAuthTempData{
 		Info:      info,
 		ExpiresAt: time.Now().Add(5 * time.Minute),
 	}
-	OAuthTempStore.Unlock()
+
+	_ = SetOAuthTemp(rdb, stateID, data, 5*time.Minute)
 	return stateID
-}
-
-func CleanMemory(phone, stateID string) {
-	OtpStore.Lock()
-	delete(OtpStore.M, phone)
-	OtpStore.Unlock()
-
-	OAuthTempStore.Lock()
-	delete(OAuthTempStore.M, stateID)
-	OAuthTempStore.Unlock()
 }


### PR DESCRIPTION
- Replaced in-memory OTP and OAuthTemp storage with Redis for improved scalability and persistence.
- Added a Redis connection utility (connect_redis.go) and ensured the Redis client is initialized at server startup.
- Refactored OTP and OAuthTemp utility functions in `otp.go` to use Redis, including new naming conventions for clarity
- Updated the auth service and handler layers to inject and use the Redis client instance, removing all import cycles
- Improved route registration to pass the Redis client where needed
- Cleaned up legacy in-memory map code and ensured all temporary authentication data now auto-expires via Redis TTL