### PR TITLE
🌐 api: send signup form endpoint

### DIFF
--- a/infrastructure/routes/auth.go
+++ b/infrastructure/routes/auth.go
@@ -6,6 +6,8 @@ import (
 	"gorm.io/gorm"
 
 	"food-delivery-app-server/internal/auth"
+	"food-delivery-app-server/middleware"
+	"food-delivery-app-server/models"
 )
 
 func RegisterAuthRoutes(r *gin.Engine, DB *gorm.DB, rdb *redis.Client) {
@@ -22,4 +24,9 @@ func RegisterAuthRoutes(r *gin.Engine, DB *gorm.DB, rdb *redis.Client) {
 		authGroup.POST("/signout", authHandler.SignOut)
 	}
 
+	adminOnly := authGroup.Group("/", middleware.JWTAuthMiddleware(), middleware.RequireRoles(models.Admin))
+	{
+		adminOnly.POST("/send-signup", authHandler.SendSignUpForm)
+		adminOnly.POST("/signup-approval")
+	}
 }

--- a/internal/auth/dto.go
+++ b/internal/auth/dto.go
@@ -48,3 +48,9 @@ type VerifyOTPRequest struct {
 	Phone   string `json:"phone"`
 	OTP     string `json:"otp"`
 }
+
+// Admin Actions
+type SendSignUpFormRequest struct {
+	Email string `json:"email" binding:"required,email"`
+	Role  string `json:"role" binding:"required"`
+}

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -148,3 +148,20 @@ func (h *Handler) SignOut(c *gin.Context) {
 		"message": "You have signed out successfully",
 	})
 }
+
+func (h *Handler) SendSignUpForm(c *gin.Context) {
+	req, err := http_helper.BindJSON[SendSignUpFormRequest](c)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	if err := h.service.SendSignUpForm(*req); err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(200, gin.H{
+		"message": "A sign up form invitation with link was sent to the provided email",
+	})
+}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"food-delivery-app-server/models"
+	"food-delivery-app-server/pkg/email"
 	appErr "food-delivery-app-server/pkg/errors"
 	"food-delivery-app-server/pkg/geocode"
 	"food-delivery-app-server/pkg/oauth"
@@ -290,4 +291,26 @@ func (s *Service) VerifyOTP(req VerifyOTPRequest) (*JWTAuthResponse, string, err
 	}
 
 	return &userResponse, token, nil
+}
+
+func (s *Service) SendSignUpForm(req SendSignUpFormRequest) error {
+	emailAddr := req.Email
+	role := req.Role
+
+	existingUser, err := s.repo.FindUserByEmail(emailAddr)
+	if err != nil {
+		return appErr.NewBadRequest("Failed to verify if the email exists", err)
+	}
+
+	if existingUser != nil {
+		return appErr.NewBadRequest("User with that email already exists", nil)
+	}
+
+	signupURL := "http://localhost:3000/owner&driver/signup"
+
+	if err := email.SendSignUpForm(emailAddr, role, signupURL); err != nil {
+		return appErr.NewBadRequest("Invalid Email or User Role", err)
+	}
+
+	return nil
 }

--- a/pkg/email/email.go
+++ b/pkg/email/email.go
@@ -25,35 +25,38 @@ func fallback(origValue, fallback string) string {
 	return origValue
 }
 
+func getSMTPConfig() (smtpServer, smtpPort, sender, password string) {
+	smtpServer = fallback(os.Getenv("SMTP_SERVER"), "smtp.gmail.com")
+	smtpPort = fallback(os.Getenv("SMTP_PORT"), "587")
+	sender = os.Getenv("SMTP_EMAIL")
+	password = os.Getenv("SMTP_PASSWORD")
+	return
+}
+
 func SendResetCode(to string, code string) error {
-
-	smtpServer := fallback(os.Getenv("SMTP_SERVER"), "smtp.gmail.com")
-	smtpPort := fallback(os.Getenv("SMTP_PORT"), "587")
-	sender := os.Getenv("SMTP_EMAIL")
-	password := os.Getenv("SMTP_PASSWORD")
-
-	emailBody := fmt.Sprintf(`
-    	<div style="font-family: Arial, sans-serif; line-height:1.6; color: #545454;">
-        	<h1 style="font-size: 24px; font-weight: bold; color:#d417ff">
-            	Food Delivery App Password Reset
-        	</h1>
-        	<p style="font-size:16px; margin-bottom:10px">
-            	Your verification code is
-            	<strong style="font-size: 18px; color:#d417ff;">%s</strong>
-        	</p>
-        	<p style="font-size: 14px; margin-bottom: 20px;">
-            	The code expires in <strong>5 minutes</strong> after this email was sent.
-        	</p>
-        	<p style="font-size: 14px;">
-            	Enter the code in the reset password section of the app to reset your password.
-        	</p>
-        	<hr style="border: 0; border-top: 1px solid #ccc; margin: 20px 0;">
-        	<p style="font-size: 12px; color: #999;">
-            	If you did not request a password reset, please ignore this email.
-        	</p>
-    	</div>`, code)
+	smtpServer, smtpPort, sender, password := getSMTPConfig()
+	emailBody := fmt.Sprintf(ResetPasswordTemplate, code)
 
 	subject := "Food Delivery App Password Reset"
+	body := emailBody
+	msg := []byte("Subject: " + subject + "\r\n" +
+		"MIME-Version: 1.0\r\n" +
+		"Content-Type: text/html; charset=\"UTF-8\"\r\n" +
+		"To: " + to + "\r\n" +
+		"From: " + sender + "\r\n" +
+		"\r\n" +
+		body + "\r\n")
+
+	auth := smtp.PlainAuth("", sender, password, smtpServer)
+	addr := smtpServer + ":" + smtpPort
+	return smtp.SendMail(addr, auth, sender, []string{to}, msg)
+}
+
+func SendSignUpForm(to, role, sigupURL string) error {
+	smtpServer, smtpPort, sender, password := getSMTPConfig()
+	emailBody := fmt.Sprintf(SignUpFormTemplate, role, sigupURL, sigupURL)
+
+	subject := "Food Delivery App Sign Up Invitation"
 	body := emailBody
 	msg := []byte("Subject: " + subject + "\r\n" +
 		"MIME-Version: 1.0\r\n" +

--- a/pkg/email/templates.go
+++ b/pkg/email/templates.go
@@ -1,0 +1,39 @@
+package email
+
+const ResetPasswordTemplate = `
+    <div style="font-family: Arial, sans-serif; line-height:1.6; color: #545454;">
+        <h1 style="font-size: 24px; font-weight: bold; color:#d417ff">
+            Food Delivery App Password Reset
+        </h1>
+        <p style="font-size:16px; margin-bottom:10px">
+            Your verification code is
+            <strong style="font-size: 18px; color:#d417ff;">%s</strong>
+        </p>
+        <p style="font-size: 14px; margin-bottom: 20px;">
+            The code expires in <strong>5 minutes</strong> after this email was sent.
+        </p>
+        <p style="font-size: 14px;">
+            Enter the code in the reset password section of the app to reset your password.
+        </p>
+        <hr style="border: 0; border-top: 1px solid #ccc; margin: 20px 0;">
+        <p style="font-size: 12px; color: #999;">
+            If you did not request a password reset, please ignore this email.
+        </p>
+    </div>`
+
+const SignUpFormTemplate = `
+    <div style="font-family: Arial, sans-serif; line-height:1.6; color: #545454;">
+        <h1 style="font-size: 24px; font-weight: bold; color:#d417ff">
+            Food Delivery App Admin Invitation
+        </h1>
+        <p style="font-size:16px; margin-bottom:10px">
+            You have been invited to sign up as %s.<br>
+            Please use the following link to complete your registration:
+        </p>
+        <p>
+            <a href="%s" style="font-size: 18px; color:#d417ff;">%s</a>
+        </p>
+        <p style="font-size: 14px;">
+            If you did not expect this invitation, you can ignore this email.
+        </p>
+    </div>`


### PR DESCRIPTION
✨ Implemented the send sign up form endpoint for ADMIN role

- Added a new admin-only API endpoint /auth/send-signup to send a sign-up invitation link to a specified email address
- Implemented request/response DTOs and handler/service logic for sending the invitation
- Integrated email sending utility with a new HTML template for sign-up invitations
- Refactored email template strings into a separate `templates.go` file for better organization and maintainability
- Improved SMTP configuration handling for reliability and security
- Added user existence check to prevent sending invitations to already registered emails