### PR TITLE
🧹chore: added token on signup link to ensure access security 

### DIFF
--- a/internal/auth/dto.go
+++ b/internal/auth/dto.go
@@ -19,6 +19,7 @@ type SignUpRequest struct {
 	Address         string
 	Password        string
 	ConfirmPassword string
+	Token           string
 	Role            Role
 }
 

--- a/pkg/email/templates.go
+++ b/pkg/email/templates.go
@@ -34,6 +34,9 @@ const SignUpFormTemplate = `
             <a href="%s" style="font-size: 18px; color:#d417ff;">%s</a>
         </p>
         <p style="font-size: 14px;">
+            This invitation link expires 12 hours after this email is sent.
+        </p>
+        <p style="font-size: 14px;">
             If you did not expect this invitation, you can ignore this email.
         </p>
     </div>`


### PR DESCRIPTION
- Added a unique, random token to each admin-invited sign-up link for enhanced security

- Token is stored in Redis with associated email and role, and expires after 12 hours

- Sign-up endpoint now requires and validates the token, ensuring only invited users can register

- Updated email invitation template to inform users of the 12-hour link expiration

- Prevents registration with expired or reused invitation links