### PR TITLE
105 feature cancel order endpoint

### DIFF
--- a/infrastructure/routes/order.go
+++ b/infrastructure/routes/order.go
@@ -16,12 +16,12 @@ func RegisterOrderRoutes(r *gin.Engine, DB *gorm.DB) {
 
 	allRoles := order.Group("/")
 	{
-		allRoles.GET("/:id", orderHandler.GetOrderDetails) //not yet functional
+		allRoles.GET("/:id", orderHandler.GetOrderDetails)
 	}
 
 	ownerAndDriver := order.Group("/", middleware.RequireRoles(models.Owner, models.Driver))
 	{
-		ownerAndDriver.PUT("/:id", orderHandler.UpdateOrderStatus) //not yet functional
+		ownerAndDriver.PUT("/:id", orderHandler.UpdateOrderStatus)
 	}
 
 	custAndDriver := order.Group("/", middleware.RequireRoles(models.Customer, models.Driver))
@@ -37,7 +37,7 @@ func RegisterOrderRoutes(r *gin.Engine, DB *gorm.DB) {
 	customer := order.Group("/", middleware.RequireRoles(models.Customer))
 	{
 		customer.POST("/restaurant/:id", orderHandler.PlaceOrder)
-		customer.PUT("/:id/cancel", orderHandler.CancelOrder) //not yet functional
+		customer.PUT("/:id/cancel", orderHandler.CancelOrder)
 	}
 
 	driver := order.Group("/", middleware.RequireRoles(models.Driver))

--- a/internal/order/customer.go
+++ b/internal/order/customer.go
@@ -8,13 +8,20 @@ import (
 
 func (h *Handler) PlaceOrder(c *gin.Context) {
 	restaurantID := c.Param("id")
+
+	userID, err := http_helper.ExtractUserIDFromContext(c)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
 	req, err := http_helper.BindJSON[PlaceOrderRequest](c)
 	if err != nil {
 		c.Error(err)
 		return
 	}
 
-	orderRes, err := h.service.PlaceOrder(restaurantID, *req)
+	orderRes, err := h.service.PlaceOrder(restaurantID, userID, *req)
 	if err != nil {
 		c.Error(err)
 		return

--- a/internal/order/customer.go
+++ b/internal/order/customer.go
@@ -27,5 +27,18 @@ func (h *Handler) PlaceOrder(c *gin.Context) {
 }
 
 func (h *Handler) CancelOrder(c *gin.Context) {
-	c.JSON(200, gin.H{"message": "Cancel Order Endpoint"})
+	orderId := c.Param("id")
+
+	userId, err := http_helper.ExtractUserIDFromContext(c)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	if err := h.service.CancelOrder(orderId, userId); err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(200, gin.H{"message": "Your order has been canceled"})
 }

--- a/internal/order/service.go
+++ b/internal/order/service.go
@@ -153,3 +153,41 @@ func (s *Service) UpdateOrderStatus(req UpdateOrderStatusRequest, orderId string
 
 	return nil
 }
+
+func (s *Service) CancelOrder(orderId string, userId string) error {
+	orID, err := utils.ParseId(orderId)
+	if err != nil {
+		return appErr.NewBadRequest("Invalid order ID", err)
+	}
+
+	uID, err := utils.ParseId(userId)
+	if err != nil {
+		return appErr.NewBadRequest("Invalid user ID", err)
+	}
+
+	order, err := s.repo.GetOrderDetailsByID(orID)
+	if err != nil {
+		return appErr.NewInternal("Order not found", err)
+	}
+
+	if order.Status != models.Pending && order.Status != models.AcceptedByOwner {
+		return appErr.NewBadRequest("Order cannot be canceled at this stage", nil)
+	}
+
+	if order.CustomerID == nil || *order.CustomerID != uID {
+		return appErr.NewUnauthorized("You are not allowed to cancel this order", nil)
+	}
+
+	if order.Status == models.AcceptedByOwner {
+		if time.Since(order.UpdatedAt) > 1*time.Minute {
+			return appErr.NewBadRequest("You can only cancel within 3 minutes after acceptance", nil)
+		}
+	}
+
+	cancelStatus := string(models.Canceled)
+	if err := s.repo.UpdateOrderStatus(orID, cancelStatus); err != nil {
+		return appErr.NewInternal("Failed to cancel the order", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
**Customer Cancel Order Endpoint**

- Implemented the CancelOrder endpoint, allowing customers to cancel their orders
- Customers can only cancel orders that are in PENDING or ACCEPTED_BY_OWNER status
- Added a time restriction: cancellation after owner acceptance is only allowed within 3 minutes
- Ensured only the customer who placed the order can cancel it
- Updated the PlaceOrder logic to correctly associate the customer ID with the order
- Improved user ID extraction and validation for both placing and canceling orders
- Cleaned up and activated related routes and handlers for order cancellation