### PR TITLE
109 refactor driver and owner sign up endpoint

### DIFF
--- a/infrastructure/routes/auth.go
+++ b/infrastructure/routes/auth.go
@@ -25,6 +25,6 @@ func RegisterAuthRoutes(r *gin.Engine, DB *gorm.DB, rdb *redis.Client) {
 
 	adminOnly := authGroup.Group("/", middleware.JWTAuthMiddleware(), middleware.RequireRoles(models.Admin))
 	{
-		adminOnly.POST("/signup/driver", authHandler.SignUpDriver)
+		adminOnly.POST("/signup/:role", authHandler.SignUp)
 	}
 }

--- a/infrastructure/routes/auth.go
+++ b/infrastructure/routes/auth.go
@@ -15,7 +15,6 @@ func RegisterAuthRoutes(r *gin.Engine, DB *gorm.DB, rdb *redis.Client) {
 
 	authGroup := r.Group("/auth")
 	{
-		authGroup.POST("/signup", authHandler.SignUp)
 		authGroup.POST("/signin", authHandler.SignIn)
 		authGroup.POST("/oauth-signup/:provider", authHandler.OAuthSignUp)
 		authGroup.POST("/oauth-signin/:provider", authHandler.OAuthSignIn)
@@ -26,7 +25,6 @@ func RegisterAuthRoutes(r *gin.Engine, DB *gorm.DB, rdb *redis.Client) {
 
 	adminOnly := authGroup.Group("/", middleware.JWTAuthMiddleware(), middleware.RequireRoles(models.Admin))
 	{
-		adminOnly.POST("/send-signup", authHandler.SendSignUpForm)
-		adminOnly.POST("/pending-signups/:id/decision", authHandler.SignUpDecision)
+		adminOnly.POST("/signup/driver", authHandler.SignUpDriver)
 	}
 }

--- a/internal/auth/dto.go
+++ b/internal/auth/dto.go
@@ -13,16 +13,14 @@ const (
 )
 
 type SignUpRequest struct {
-	FirstName       string
-	LastName        string
-	Email           string
-	Bio             string
-	Phone           string
-	Address         string
-	Password        string
-	ConfirmPassword string
-	Token           string
-	Role            Role
+	FirstName string
+	LastName  string
+	Email     string
+	Bio       string
+	Phone     string
+	Address   string
+	Token     string
+	Role      Role
 }
 
 type JWTAuthResponse struct {

--- a/internal/auth/dto.go
+++ b/internal/auth/dto.go
@@ -19,8 +19,6 @@ type SignUpRequest struct {
 	Bio       string
 	Phone     string
 	Address   string
-	Token     string
-	Role      Role
 }
 
 type JWTAuthResponse struct {

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -21,22 +21,25 @@ func NewHandler(db *gorm.DB, rdb *redis.Client) *Handler {
 	return &Handler{service: service}
 }
 
-func (h *Handler) SignUpDriver(c *gin.Context) {
+func (h *Handler) SignUp(c *gin.Context) {
+	role := c.Param("role")
 	req, err := http_helper.BindJSON[SignUpRequest](c)
 	if err != nil {
 		c.Error(err)
 		return
 	}
 
-	signUpID, err := h.service.SignUpDriver(*req)
+	newUser, token, err := h.service.SignUp(*req, role)
 	if err != nil {
 		c.Error(err)
 		return
 	}
 
+	utils.SetCookie(c, token, 3600*5)
+
 	c.JSON(200, gin.H{
-		"message":  "Your application has been sent to admin for approval",
-		"signUpID": signUpID,
+		"message": "A new user has been created. Email was sent to the user with temporary password",
+		"user":    newUser,
 	})
 }
 

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -21,14 +21,14 @@ func NewHandler(db *gorm.DB, rdb *redis.Client) *Handler {
 	return &Handler{service: service}
 }
 
-func (h *Handler) SignUp(c *gin.Context) {
+func (h *Handler) SignUpDriver(c *gin.Context) {
 	req, err := http_helper.BindJSON[SignUpRequest](c)
 	if err != nil {
 		c.Error(err)
 		return
 	}
 
-	signUpID, err := h.service.SignUp(*req)
+	signUpID, err := h.service.SignUpDriver(*req)
 	if err != nil {
 		c.Error(err)
 		return
@@ -145,54 +145,5 @@ func (h *Handler) SignOut(c *gin.Context) {
 
 	c.JSON(200, gin.H{
 		"message": "You have signed out successfully",
-	})
-}
-
-func (h *Handler) SendSignUpForm(c *gin.Context) {
-	req, err := http_helper.BindJSON[SendSignUpFormRequest](c)
-	if err != nil {
-		c.Error(err)
-		return
-	}
-
-	if err := h.service.SendSignUpForm(*req); err != nil {
-		c.Error(err)
-		return
-	}
-
-	c.JSON(200, gin.H{
-		"message": "A sign up form invitation with link was sent to the provided email",
-	})
-}
-
-func (h *Handler) SignUpDecision(c *gin.Context) {
-	signUpID := c.Param("id")
-	req, err := http_helper.BindJSON[SignUpDecisionRequest](c)
-	if err != nil {
-		c.Error(err)
-		return
-	}
-
-	userResData, token, err := h.service.SignUpDecision(*req, signUpID)
-	if err != nil {
-		c.Error(err)
-		return
-	}
-
-	if req.IsAccepted == nil {
-		c.JSON(400, gin.H{"error": "isAccepted is required"})
-		return
-	}
-
-	if !*req.IsAccepted {
-		c.JSON(200, gin.H{"message": "Sign Up Application has been rejected"})
-		return
-	}
-
-	utils.SetCookie(c, token, 3600*5)
-
-	c.JSON(200, gin.H{
-		"message": "Sign Up Application has been decided",
-		"user":    userResData,
 	})
 }

--- a/internal/auth/repo.go
+++ b/internal/auth/repo.go
@@ -25,19 +25,31 @@ func (r *Repository) FindUserByEmail(email string) (*models.User, error) {
 	return &user, nil
 }
 
-func (r *Repository) CreateUser(user *models.User) (*models.User, error) {
+func (r *Repository) CreateUser(user *models.User, addr *models.Address) (*models.User, error) {
+	tx := r.db.Begin()
 	if err := r.db.Create(user).Error; err != nil {
+		tx.Rollback()
 		return nil, err
 	}
+
+	if addr != nil {
+		if err := r.db.Create(addr).Error; err != nil {
+			tx.Rollback()
+			return nil, err
+		}
+	}
+
+	tx.Commit()
+
 	return user, nil
 }
 
-func (r *Repository) CreateAddress(address *models.Address) (*models.Address, error) {
-	if err := r.db.Create(address).Error; err != nil {
-		return nil, err
-	}
-	return address, nil
-}
+// func (r *Repository) CreateAddress(address *models.Address) (*models.Address, error) {
+// 	if err := r.db.Create(address).Error; err != nil {
+// 		return nil, err
+// 	}
+// 	return address, nil
+// }
 
 func (r *Repository) FindFacebookUserByProfilePicturePrefix(string) (*models.User, error) {
 	prefix := "https://platform-lookaside.fbsbx.com"

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -3,13 +3,10 @@ package auth
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"log"
 	"strings"
 	"time"
 
 	"food-delivery-app-server/models"
-	"food-delivery-app-server/pkg/email"
 	appErr "food-delivery-app-server/pkg/errors"
 	"food-delivery-app-server/pkg/geocode"
 	"food-delivery-app-server/pkg/oauth"
@@ -30,9 +27,9 @@ func NewService(repo *Repository, rdb *redis.Client) *Service {
 	return &Service{repo: repo, rdb: rdb}
 }
 
-func (s *Service) SignUp(req SignUpRequest) (string, error) {
+func (s *Service) SignUpDriver(req SignUpRequest) (string, error) {
 	// Missing Required Validation
-	if req.Email == "" || req.Password == "" || req.ConfirmPassword == "" || req.Address == "" ||
+	if req.Email == "" || req.Address == "" ||
 		req.FirstName == "" || req.LastName == "" || req.Bio == "" || req.Phone == "" {
 		return "", appErr.NewBadRequest("Missing required fields", nil)
 	}
@@ -40,11 +37,6 @@ func (s *Service) SignUp(req SignUpRequest) (string, error) {
 	// Validate Phone Format
 	if err := sms.ValidatePhone(req.Phone); err != nil {
 		return "", appErr.NewBadRequest("Invalid Phone Number Format", err)
-	}
-
-	// Password Mismatch
-	if req.Password != req.ConfirmPassword {
-		return "", appErr.NewBadRequest("Passwords do not match", nil)
 	}
 
 	// Existing User Validation
@@ -57,33 +49,6 @@ func (s *Service) SignUp(req SignUpRequest) (string, error) {
 		return "", appErr.NewBadRequest("User with that email already exists", nil)
 	}
 
-	// Sign Up Link Token Validation
-	if req.Token == "" {
-		return "", appErr.NewBadRequest("Missing invitation token", nil)
-	}
-	val, err := s.rdb.Get(context.Background(), "signup_invite:"+req.Token).Result()
-
-	if err == redis.Nil {
-		return "", appErr.NewBadRequest("Invalid or expired invitation token", nil)
-	} else if err != nil {
-		return "", appErr.NewInternal("Failed to verify invitation token", err)
-	}
-
-	var invite SendSignUpFormRequest
-	if err := json.Unmarshal([]byte(val), &invite); err != nil {
-		return "", appErr.NewInternal("Failed to parse invitation data", err)
-	}
-
-	if invite.Email != req.Email {
-		return "", appErr.NewBadRequest("Invitation token does not match email", nil)
-	}
-
-	// Password Hashing
-	hashedPassword, err := utils.HashPassword(req.Password)
-	if err != nil {
-		return "", appErr.NewInternal("Failed to hash the password", err)
-	}
-
 	// User and Address Data Preparation
 	userId := utils.GenerateUUID()
 	addressId := utils.GenerateUUID()
@@ -93,7 +58,6 @@ func (s *Service) SignUp(req SignUpRequest) (string, error) {
 		FirstName:      req.FirstName,
 		LastName:       req.LastName,
 		Email:          req.Email,
-		Password:       hashedPassword,
 		ProfilePicture: DefaultProfilePic,
 		Bio:            req.Bio,
 		Phone:          req.Phone,
@@ -127,26 +91,10 @@ func (s *Service) SignUp(req SignUpRequest) (string, error) {
 		return "", appErr.NewInternal("Failed to serialize pending signup data", err)
 	}
 
-	expiry := 10 * time.Minute
+	expiry := 30 * time.Minute
 	err = s.rdb.Set(ctx, "pending_signup:"+pendingSignUpID, data, expiry).Err()
 	if err != nil {
 		return "", appErr.NewInternal("Failed to store pending signup in Redis", err)
-	}
-
-	// Sending Admin Users Notification of Pending Sign Up
-	admins, err := s.repo.FindAdmins()
-	log.Println(admins)
-	if err == nil {
-		for _, admin := range admins {
-			notification := &models.Notification{
-				ID:      utils.GenerateUUID(),
-				UserID:  admin.ID,
-				Message: fmt.Sprintf("New sign up request from %s %s", newUser.FirstName, newUser.LastName),
-				IsRead:  false,
-			}
-
-			_ = s.repo.CreateNotification(notification)
-		}
 	}
 
 	return pendingSignUpID, nil
@@ -322,87 +270,6 @@ func (s *Service) VerifyOTP(req VerifyOTPRequest) (*JWTAuthResponse, string, err
 	if err != nil {
 		return nil, "", appErr.NewInternal("Failed to create user at database", err)
 	}
-
-	token, err := utils.GenerateJWT(createdUser)
-	if err != nil {
-		return nil, "", appErr.NewInternal("Failed to generate token", err)
-	}
-
-	userResponse := JWTAuthResponse{
-		ID:   createdUser.ID.String(),
-		Role: string(createdUser.Role),
-	}
-
-	return &userResponse, token, nil
-}
-
-func (s *Service) SendSignUpForm(req SendSignUpFormRequest) error {
-	emailAddr := req.Email
-	role := req.Role
-
-	existingUser, err := s.repo.FindUserByEmail(emailAddr)
-	if err != nil {
-		return appErr.NewBadRequest("Failed to verify if the email exists", err)
-	}
-
-	if existingUser != nil {
-		return appErr.NewBadRequest("User with that email already exists", nil)
-	}
-
-	token := utils.GenerateUUIDStr()
-
-	invite := SendSignUpFormRequest{Email: emailAddr, Role: role}
-	data, _ := json.Marshal(invite)
-
-	err = s.rdb.Set(context.Background(), "signup_invite:"+token, data, 12*time.Hour).Err()
-	if err != nil {
-		return appErr.NewInternal("Failed to store sign-up invite", err)
-	}
-
-	signupURL := fmt.Sprintf("http://localhost:3000/owner&driver/signup?token=%s", token)
-
-	if err := email.SendSignUpForm(emailAddr, role, signupURL); err != nil {
-		return appErr.NewBadRequest("Invalid Email or User Role", err)
-	}
-
-	return nil
-}
-
-func (s *Service) SignUpDecision(req SignUpDecisionRequest, signUpID string) (*JWTAuthResponse, string, error) {
-	ctx := context.Background()
-
-	// Retrieving pending sign-up data from Redis
-	val, err := s.rdb.Get(ctx, "pending_signup:"+signUpID).Result()
-	if err == redis.Nil {
-		return nil, "", appErr.NewBadRequest("Pending sign up not found", nil)
-	} else if err != nil {
-		return nil, "", appErr.NewInternal("Failed to retrieve pending sign up", err)
-	}
-
-	// Unmarshal the sign-up data
-	var pendingSignUp PendingSignUp
-	if err := json.Unmarshal([]byte(val), &pendingSignUp); err != nil {
-		return nil, "", appErr.NewInternal("Failed to parse the pending sign up data", err)
-	}
-
-	// If rejected
-	if !*req.IsAccepted {
-		_ = s.rdb.Del(ctx, "pending_signup:"+signUpID).Err()
-		return nil, "", nil
-	}
-
-	// If accepted
-	createdUser, err := s.repo.CreateUser(pendingSignUp.User)
-	if err != nil {
-		return nil, "", appErr.NewInternal("Failed to create user at database", err)
-	}
-
-	_, err = s.repo.CreateAddress(pendingSignUp.Address)
-	if err != nil {
-		return nil, "", appErr.NewInternal("Failed to create address at database", err)
-	}
-
-	_ = s.rdb.Del(ctx, "pending_signup:"+signUpID).Err()
 
 	token, err := utils.GenerateJWT(createdUser)
 	if err != nil {

--- a/models/user.go
+++ b/models/user.go
@@ -17,6 +17,7 @@ type User struct {
 	Phone          string    `gorm:"type:varchar(20)" json:"phone"`
 	Role           Role      `gorm:"type:varchar(20)" json:"role"`
 	Provider       string    `gorm:"type:text" json:"provider"`
+	Branch         *string   `gorm:"type:text" json:"branch"`
 
 	CreatedAt time.Time `gorm:"autoCreateTime" json:"createdAt"`
 	UpdatedAt time.Time `gorm:"autoUpdateTime" json:"updatedAt"`

--- a/pkg/email/email.go
+++ b/pkg/email/email.go
@@ -70,3 +70,22 @@ func SendSignUpForm(to, role, sigupURL string) error {
 	addr := smtpServer + ":" + smtpPort
 	return smtp.SendMail(addr, auth, sender, []string{to}, msg)
 }
+
+func SendWelcomeWithPassword(to, password string) error {
+	smtpServer, smtpPort, sender, smtpPassword := getSMTPConfig()
+	emailBody := fmt.Sprintf(WelcomeWithPasswordTemplate, password)
+
+	subject := "Welcome to Food Delivery App - Your Login Password"
+	body := emailBody
+	msg := []byte("Subject: " + subject + "\r\n" +
+		"MIME-Version: 1.0\r\n" +
+		"Content-Type: text/html; charset=\"UTF-8\"\r\n" +
+		"To: " + to + "\r\n" +
+		"From: " + sender + "\r\n" +
+		"\r\n" +
+		body + "\r\n")
+
+	auth := smtp.PlainAuth("", sender, smtpPassword, smtpServer)
+	addr := smtpServer + ":" + smtpPort
+	return smtp.SendMail(addr, auth, sender, []string{to}, msg)
+}

--- a/pkg/email/templates.go
+++ b/pkg/email/templates.go
@@ -40,3 +40,22 @@ const SignUpFormTemplate = `
             If you did not expect this invitation, you can ignore this email.
         </p>
     </div>`
+
+const WelcomeWithPasswordTemplate = `
+    <div style="font-family: Arial, sans-serif; line-height:1.6; color: #545454;">
+        <h1 style="font-size: 24px; font-weight: bold; color:#d417ff">
+            Welcome to Food Delivery App!
+        </h1>
+        <p style="font-size:16px; margin-bottom:10px">
+            Your account has been created.<br>
+            Here is your temporary password:
+            <strong style="font-size: 18px; color:#d417ff;">%s</strong>
+        </p>
+        <p style="font-size: 14px; margin-bottom: 20px;">
+            Please use this password to log in for the first time. You can change your password after logging in.
+        </p>
+        <hr style="border: 0; border-top: 1px solid #ccc; margin: 20px 0;">
+        <p style="font-size: 12px; color: #999;">
+            If you did not expect this email, please ignore it.
+        </p>
+    </div>`

--- a/pkg/password/generate_password.go
+++ b/pkg/password/generate_password.go
@@ -1,0 +1,21 @@
+package password
+
+import (
+	"crypto/rand"
+	"math/big"
+)
+
+const passwordChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+func GenerateRandomPassword(length int) string {
+	password := make([]byte, length)
+	for i := range password {
+		index, err := rand.Int(rand.Reader, big.NewInt(int64(len(passwordChars))))
+		if err != nil {
+			password[i] = 'a'
+			continue
+		}
+		password[i] = passwordChars[index.Int64()]
+	}
+	return string(password)
+}


### PR DESCRIPTION
**Auth Flow Revision for Driver & Owner Sign Up**

- Refactored driver/owner sign-up to use a single /auth/signup/:role endpoint, simplifying the admin onboarding process
- Implemented auto-generation of a secure 7-character password for new users, which is hashed before saving to the database
Added email utility and template to send the default password to the user's email upon account creation
- Updated repository logic to support optional address creation for users

- Revised service and handler logic to remove invitation token and pending approval for driver/owner sign-up (for testing/direct creation)
- Cleaned up unused code and improved error handling for user creation and authentication
- Updated the User model to include an optional `Branch` field (will be used for role of ADMIN only)