### PR TITLE
113 feature get order history

### DIFF
--- a/infrastructure/routes/order.go
+++ b/infrastructure/routes/order.go
@@ -27,7 +27,7 @@ func RegisterOrderRoutes(r *gin.Engine, DB *gorm.DB) {
 
 	owner := order.Group("/", middleware.RequireRoles(models.Owner))
 	{
-		owner.GET("/restaurant/:id", orderHandler.GetOrderByRestaurant) //not yet functional
+		owner.GET("/restaurant/:id", orderHandler.GetOrderByRestaurant)
 	}
 
 	customer := order.Group("/", middleware.RequireRoles(models.Customer))

--- a/infrastructure/routes/order.go
+++ b/infrastructure/routes/order.go
@@ -17,16 +17,12 @@ func RegisterOrderRoutes(r *gin.Engine, DB *gorm.DB) {
 	allRoles := order.Group("/")
 	{
 		allRoles.GET("/:id", orderHandler.GetOrderDetails)
+		allRoles.GET("/history", orderHandler.GetOrderHistory) //not yet functional
 	}
 
 	ownerAndDriver := order.Group("/", middleware.RequireRoles(models.Owner, models.Driver))
 	{
 		ownerAndDriver.PUT("/:id", orderHandler.UpdateOrderStatus)
-	}
-
-	custAndDriver := order.Group("/", middleware.RequireRoles(models.Customer, models.Driver))
-	{
-		custAndDriver.GET("/history", orderHandler.GetOrderHistory) //not yet functional
 	}
 
 	owner := order.Group("/", middleware.RequireRoles(models.Owner))

--- a/infrastructure/routes/order.go
+++ b/infrastructure/routes/order.go
@@ -17,7 +17,7 @@ func RegisterOrderRoutes(r *gin.Engine, DB *gorm.DB) {
 	allRoles := order.Group("/")
 	{
 		allRoles.GET("/:id", orderHandler.GetOrderDetails)
-		allRoles.GET("/history", orderHandler.GetOrderHistory) //not yet functional
+		allRoles.GET("/history", orderHandler.GetOrderHistory)
 	}
 
 	ownerAndDriver := order.Group("/", middleware.RequireRoles(models.Owner, models.Driver))

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -164,6 +164,13 @@ func (s *Service) OAuthSignUp(req OAuthRequest, provider string) (string, error)
 		return "", appErr.NewBadRequest("Failed to verify token", err)
 	}
 
+	user, err := s.repo.FindUserByEmail(info.Email)
+	if err != nil {
+		return "", appErr.NewInternal("Failed to check existing user", err)
+	}
+	if user != nil {
+		return "", appErr.NewBadRequest("User with that email already exists", nil)
+	}
 	redisKey := utils.SetTempCustomer(s.rdb, info)
 
 	return redisKey, nil

--- a/internal/order/handler.go
+++ b/internal/order/handler.go
@@ -32,7 +32,19 @@ func (h *Handler) GetOrderDetails(c *gin.Context) {
 
 // Customer & Driver
 func (h *Handler) GetOrderHistory(c *gin.Context) {
-	c.JSON(200, gin.H{"message": "Get Order History Endpoint"})
+	userId, err := http_helper.ExtractUserIDFromContext(c)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	orders, err := h.service.GetOrderHistory(userId)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(200, gin.H{"orderHistory": orders})
 }
 
 // Owner & Driver

--- a/internal/order/owner.go
+++ b/internal/order/owner.go
@@ -2,14 +2,14 @@ package order
 
 import "github.com/gin-gonic/gin"
 
-func (h *Handler) AcceptOrderByOwner(c *gin.Context) {
-	c.JSON(200, gin.H{"message": "Accept Order By Owner Endpoint"})
-}
-
 func (h *Handler) GetOrderByRestaurant(c *gin.Context) {
-	c.JSON(200, gin.H{"message": "Get Order By Restaurant Endpoint"})
-}
+	restaurantID := c.Param("id")
 
-func (h *Handler) UpdateOrderByOwner(c *gin.Context) {
-	c.JSON(200, gin.H{"message": "Update Order Status Endpoint"})
+	orders, err := h.service.GetOrderByRestaurant(restaurantID)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(200, gin.H{"orders": orders})
 }

--- a/internal/order/repo.go
+++ b/internal/order/repo.go
@@ -118,3 +118,18 @@ func (r *Repository) GetUserRoleByID(uID uuid.UUID) (string, error) {
 	}
 	return string(user.Role), nil
 }
+
+func (r *Repository) GetOrdersByRestaurantID(restoID uuid.UUID) ([]models.Order, error) {
+	var orders []models.Order
+	err := r.db.
+		Preload("OrderItems.MenuItem").
+		Preload("Customer").
+		Preload("Driver").
+		Where("restaurant_id = ?", restoID).
+		Order("placed_at DESC").
+		Find(&orders).Error
+	if err != nil {
+		return nil, err
+	}
+	return orders, nil
+}

--- a/internal/order/repo.go
+++ b/internal/order/repo.go
@@ -86,3 +86,35 @@ func (r *Repository) UpdateOrderStatus(orderID uuid.UUID, status string) error {
 	order.Status = models.Status(status)
 	return r.db.Save(&order).Error
 }
+
+func (r *Repository) GetOrderHistoryByUser(uID uuid.UUID, role string) ([]models.Order, error) {
+	var orders []models.Order
+
+	query := r.db.
+		Preload("OrderItems.MenuItem").
+		Preload("Restaurant").
+		Order("placed_at DESC")
+
+	switch role {
+	case "CUSTOMER":
+		query = query.Where("customer_id = ?", uID)
+	case "DRIVER":
+		query = query.Where("driver_id = ?", uID)
+	default:
+		return nil, nil
+	}
+
+	if err := query.Find(&orders).Error; err != nil {
+		return nil, err
+	}
+
+	return orders, nil
+}
+
+func (r *Repository) GetUserRoleByID(uID uuid.UUID) (string, error) {
+	var user models.User
+	if err := r.db.Select("role").First(&user, "id = ?", uID).Error; err != nil {
+		return "", err
+	}
+	return string(user.Role), nil
+}

--- a/internal/order/service.go
+++ b/internal/order/service.go
@@ -96,8 +96,18 @@ func (s *Service) PlaceOrder(restaurantID string, userID string, orderReq PlaceO
 	return orderRes, nil
 }
 
-func (s *Service) GetOrderByRestaurant() {
+func (s *Service) GetOrderByRestaurant(restaurantID string) ([]models.Order, error) {
+	restoID, err := utils.ParseId(restaurantID)
+	if err != nil {
+		return nil, appErr.NewBadRequest("Invalid restaurant ID", err)
+	}
 
+	orders, err := s.repo.GetOrdersByRestaurantID(restoID)
+	if err != nil {
+		return nil, appErr.NewInternal("Failed to get orders for restaurant", err)
+	}
+
+	return orders, nil
 }
 
 func (s *Service) GetOrderDetails(orderId string) (*models.Order, error) {

--- a/internal/order/service.go
+++ b/internal/order/service.go
@@ -114,8 +114,23 @@ func (s *Service) GetOrderDetails(orderId string) (*models.Order, error) {
 	return order, nil
 }
 
-func (s *Service) GetOrderHistory() {
+func (s *Service) GetOrderHistory(userId string) ([]models.Order, error) {
+	uID, err := utils.ParseId(userId)
+	if err != nil {
+		return nil, appErr.NewBadRequest("Invalid user ID", err)
+	}
 
+	role, err := s.repo.GetUserRoleByID(uID)
+	if err != nil {
+		return nil, appErr.NewInternal("Failed to get user role", err)
+	}
+
+	orders, err := s.repo.GetOrderHistoryByUser(uID, role)
+	if err != nil {
+		return nil, appErr.NewInternal("Failed to get the order history", err)
+	}
+
+	return orders, nil
 }
 
 func (s *Service) GetAvailableOrders() {


### PR DESCRIPTION
**Order History & Get Orders by Restaurant Endpoints**

- Implemented `GET /orders/history` endpoint for customers and drivers to view their order history, with role-based filtering and preloaded related data
- Implemented `GET /orders/restaurant/:id` endpoint for owners to retrieve all orders for a specific restaurant, including order items, customer, and driver details
- Added repository methods for fetching order history by user and orders by restaurant, as well as user role lookup by ID
- Updated service and handler layers to support new endpoints and improved error handling
- Added validation to OAuth sign-up to prevent duplicate email registration
- Cleaned up route definitions and removed redundant code