### PR TITLE
🌐 api: create address endpoint

### DIFF
--- a/internal/address/dto.go
+++ b/internal/address/dto.go
@@ -1,0 +1,13 @@
+package address
+
+type CreateAddressRequest struct {
+	Address   string `json:"address"`
+	Label     string `json:"label"`
+	IsDefault bool   `json:"isDefault"`
+}
+
+type UpdateAddressRequest struct {
+	Address   *string `json:"address,omitempty"`
+	Label     *string `json:"label,omitempty"`
+	IsDefault *bool   `json:"isDefault,omitempty"`
+}

--- a/internal/address/handler.go
+++ b/internal/address/handler.go
@@ -3,6 +3,8 @@ package address
 import (
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
+
+	http_helper "food-delivery-app-server/pkg/http"
 )
 
 type Handler struct {
@@ -16,7 +18,25 @@ func NewHandler(db *gorm.DB) *Handler {
 }
 
 func (h *Handler) CreateAddress(c *gin.Context) {
-	c.JSON(200, gin.H{"message": "Create Address Endpoint"})
+	req, err := http_helper.BindJSON[CreateAddressRequest](c)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	userId, err := http_helper.ExtractUserIDFromContext(c)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	newAddr, err := h.service.CreateAddress(*req, userId)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(200, newAddr)
 }
 
 func (h *Handler) GetAddress(c *gin.Context) {

--- a/internal/address/repo.go
+++ b/internal/address/repo.go
@@ -1,6 +1,12 @@
 package address
 
-import "gorm.io/gorm"
+import (
+	"food-delivery-app-server/models"
+	appErr "food-delivery-app-server/pkg/errors"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
 
 type Repository struct {
 	db *gorm.DB
@@ -8,6 +14,29 @@ type Repository struct {
 
 func NewRepository(db *gorm.DB) *Repository {
 	return &Repository{db: db}
+}
+
+func (r *Repository) CreateAddress(addr *models.Address, uId uuid.UUID) (*models.Address, error) {
+	err := r.db.Create(addr).Error
+	if err != nil {
+		return nil, appErr.NewInternal("Failed to create address", err)
+	}
+
+	return addr, nil
+}
+
+func (r *Repository) FindAddressByUser(address string, uId uuid.UUID) (*models.Address, error) {
+	var addr models.Address
+
+	err := r.db.Where("user_id = ? AND address = ?", uId, address).First(&addr).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, appErr.NewInternal("Failed to check existing address", err)
+	}
+
+	return &addr, nil
 }
 
 func (r *Repository) GetAddress() {

--- a/internal/address/service.go
+++ b/internal/address/service.go
@@ -1,5 +1,14 @@
 package address
 
+import (
+	"food-delivery-app-server/models"
+	appErr "food-delivery-app-server/pkg/errors"
+	"food-delivery-app-server/pkg/geocode"
+	"food-delivery-app-server/pkg/utils"
+
+	"context"
+)
+
 type Service struct {
 	repo *Repository
 }
@@ -8,8 +17,45 @@ func NewService(repo *Repository) *Service {
 	return &Service{repo: repo}
 }
 
-func (s *Service) CreateAddress() {
+func (s *Service) CreateAddress(req CreateAddressRequest, userId string) (*models.Address, error) {
+	addr := req.Address
 
+	uId, err := utils.ParseId(userId)
+	if err != nil {
+		return nil, appErr.NewBadRequest("Invalid User ID", err)
+	}
+
+	existingAddr, err := s.repo.FindAddressByUser(addr, uId)
+	if err != nil {
+		return nil, err
+	}
+	if existingAddr != nil {
+		return nil, appErr.NewBadRequest("Address already exists for this user", nil)
+	}
+
+	ctx := context.Background()
+	lat, long, err := geocode.Geocode(ctx, addr)
+	if err != nil {
+		return nil, appErr.NewInternal("Failed to geocode the provided address", err)
+	}
+
+	addrId := utils.GenerateUUID()
+	createAddr := &models.Address{
+		ID:        addrId,
+		UserID:    &uId,
+		Address:   addr,
+		Label:     req.Label,
+		IsDefault: req.IsDefault,
+		Latitude:  lat,
+		Longitude: long,
+	}
+
+	newAddr, err := s.repo.CreateAddress(createAddr, uId)
+	if err != nil {
+		return nil, appErr.NewInternal("Failed to create address", err)
+	}
+
+	return newAddr, nil
 }
 
 func (s *Service) GetAddress() {


### PR DESCRIPTION
- Implemented the Create Address API endpoint with validation and geocoding
- Prevents users from creating duplicate addresses
- Ensures only one default address per user or restaurant using GORM model hooks
- Added DTOs for address creation and update requests
- Refactored repository and service layers to support address creation and validation logic