### PR TITLE
🌐 api: mark notification as read

### DIFF
--- a/infrastructure/routes/notification.go
+++ b/infrastructure/routes/notification.go
@@ -14,7 +14,7 @@ func RegisterNotificationRoutes(r *gin.Engine, DB *gorm.DB) {
 	notifGroup := r.Group("/notifications", middleware.JWTAuthMiddleware())
 	{
 		notifGroup.GET("/", notifHandler.GetUserNotifications)
-		notifGroup.PUT("/:id/read", notifHandler.MarkNotificationAsRead)          //not yet functional
+		notifGroup.PUT("/:id/read", notifHandler.MarkNotificationAsRead)
 		notifGroup.PUT("/mark-all-read", notifHandler.MarkAllNotificationsAsRead) //not yet functional
 	}
 }

--- a/internal/notification/handler.go
+++ b/internal/notification/handler.go
@@ -34,7 +34,20 @@ func (h *Handler) GetUserNotifications(c *gin.Context) {
 }
 
 func (h *Handler) MarkNotificationAsRead(c *gin.Context) {
-	c.JSON(200, gin.H{"message": "Mark Notification As Read Endpoint"})
+	notificationId := c.Param("id")
+	userId, err := http_helper.ExtractUserIDFromContext(c)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	err = h.service.MarkNotificationAsRead(notificationId, userId)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(200, gin.H{"message": "Notification marked as read successfully"})
 }
 
 func (h *Handler) MarkAllNotificationsAsRead(c *gin.Context) {

--- a/internal/notification/repo.go
+++ b/internal/notification/repo.go
@@ -24,3 +24,19 @@ func (r *Repository) GetUserNotifications(userId uuid.UUID) ([]models.Notificati
 	}
 	return notifications, nil
 }
+
+func (r *Repository) MarkNotificationAsRead(nId, uId uuid.UUID) error {
+	res := r.db.Model(&models.Notification{}).
+		Where("id = ? AND user_id = ?", nId, uId).
+		Update("is_read", true)
+
+	if res.Error != nil {
+		return res.Error
+	}
+
+	if res.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+
+	return nil
+}

--- a/internal/notification/service.go
+++ b/internal/notification/service.go
@@ -28,3 +28,21 @@ func (s *Service) GetUserNotifications(userId string) ([]models.Notification, er
 	}
 	return notifications, nil
 }
+
+func (s *Service) MarkNotificationAsRead(notificationId, userId string) error {
+	nId, err := uuid.Parse(notificationId)
+	if err != nil {
+		return appErr.NewBadRequest("Invalid notification ID", err)
+	}
+
+	uId, err := uuid.Parse(userId)
+	if err != nil {
+		return appErr.NewBadRequest("Invalid user ID", err)
+	}
+
+	err = s.repo.MarkNotificationAsRead(nId, uId)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
✨ Implemented mark notification as read functionality   **Route:** PUT /notifications/:id/read endpoint

- Added repository layer method - Created MarkNotificationAsRead method that updates the is_read field for a specific notification belonging to the authenticated user

- Added UUID validation and error handling for both notification ID and user ID parameters

- Updated the handler to extract notification ID from URL params and user ID from JWT context, then call the service layer

- Added security validation - Ensures users can only mark their own notifications as read by checking both notification ID and user ID in the database query

- Returns appropriate error responses when notification is not found or doesn't belong to the user