### PR TITLE
132 create notification on status updates

### DIFF
--- a/internal/order/service.go
+++ b/internal/order/service.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"food-delivery-app-server/models"
+	"food-delivery-app-server/pkg/notifications"
 	"food-delivery-app-server/pkg/utils"
 
 	"github.com/google/uuid"
@@ -208,11 +209,13 @@ func (s *Service) UpdateOrderStatus(req UpdateOrderStatusRequest, orderId string
 		return appErr.NewInternal("Failed to update the order status", err)
 	}
 
+	_ = notifications.CreateStatusChangeNotifications(s.repo, order, newStatus)
+
 	return nil
 }
 
 func (s *Service) UpdateDriverOrderStatus(req UpdateOrderStatusRequest, orderId string, driverId string) error {
-	if req.Status != "ACCEPTED_BY_DRIVER" && req.Status != "REJECTED_BY_DRIVER" {
+	if req.Status != "ACCEPTED_BY_DRIVER" && req.Status != "REJECTED_BY_DRIVER" && req.Status != "IN_TRANSIT" && req.Status != "DELIVERED" {
 		return appErr.NewBadRequest("Invalid request status by driver", nil)
 	}
 
@@ -231,8 +234,30 @@ func (s *Service) UpdateDriverOrderStatus(req UpdateOrderStatusRequest, orderId 
 		return appErr.NewInternal("Order not found", err)
 	}
 
-	if order.Status != models.ReadyForPickUp || order.DriverID != nil {
-		return appErr.NewBadRequest("Order not available for driver assignment", nil)
+	switch req.Status {
+	case string(models.AcceptedByDriver):
+		if order.Status != models.ReadyForPickUp || order.DriverID != nil {
+			return appErr.NewBadRequest("Order not available for driver assignment", nil)
+		}
+		order.Status = models.AcceptedByDriver
+		order.DriverID = &drID
+	case string(models.RejectedByDriver):
+		if order.Status != models.ReadyForPickUp || order.DriverID != nil {
+			return appErr.NewBadRequest("Order not available for driver assignment", nil)
+		}
+		order.Status = models.RejectedByDriver
+	case string(models.InTransit):
+		if order.Status != models.AcceptedByDriver || order.DriverID == nil || *order.DriverID != drID {
+			return appErr.NewBadRequest("Order must be accepted by this driver before marking as in transit", nil)
+		}
+		order.Status = models.InTransit
+	case string(models.Delivered):
+		if order.Status != models.InTransit || order.DriverID == nil || *order.DriverID != drID {
+			return appErr.NewBadRequest("Order must be in transit by this driver before marking as delivered", nil)
+		}
+		order.Status = models.Delivered
+	default:
+		return appErr.NewBadRequest("Invalid status transition", nil)
 	}
 
 	if req.Status == string(models.AcceptedByDriver) {
@@ -245,6 +270,9 @@ func (s *Service) UpdateDriverOrderStatus(req UpdateOrderStatusRequest, orderId 
 	if err := s.repo.UpdateOrderStatusAndDriver(order); err != nil {
 		return appErr.NewInternal("Failed to update order status", err)
 	}
+
+	_ = notifications.CreateStatusChangeNotifications(s.repo, order, order.Status)
+
 	return nil
 }
 
@@ -282,6 +310,8 @@ func (s *Service) CancelOrder(orderId string, userId string) error {
 	if err := s.repo.UpdateOrderStatus(orID, cancelStatus); err != nil {
 		return appErr.NewInternal("Failed to cancel the order", err)
 	}
+
+	_ = notifications.CreateStatusChangeNotifications(s.repo, order, models.Canceled)
 
 	return nil
 }

--- a/models/notification.go
+++ b/models/notification.go
@@ -10,7 +10,7 @@ type Notification struct {
 	ID        uuid.UUID  `gorm:"primaryKey;type:uuid" json:"id"`
 	UserID    uuid.UUID  `gorm:"type:uuid;index" json:"userId"`
 	OrderID   *uuid.UUID `gorm:"type:uuid;index" json:"orderId,omitempty"`
-	Message   string     `gorm:"type:varchar(50)" json:"message"`
+	Message   string     `gorm:"type:varchar(150)" json:"message"`
 	IsRead    bool       `json:"isRead"`
 	CreatedAt time.Time  `gorm:"autoCreateTime" json:"createdAt"`
 

--- a/pkg/notifications/status.go
+++ b/pkg/notifications/status.go
@@ -1,0 +1,191 @@
+package notifications
+
+import (
+	"food-delivery-app-server/models"
+	"food-delivery-app-server/pkg/utils"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type NotificationRepo interface {
+	CreateNotification(notification *models.Notification) error
+	GetRestaurantByID(id uuid.UUID) (*models.Restaurant, error)
+}
+
+func CreateStatusChangeNotifications(
+	repo NotificationRepo,
+	order *models.Order,
+	newStatus models.Status,
+) error {
+	var notifications []*models.Notification
+
+	switch newStatus {
+	case models.AcceptedByOwner:
+		// Notify customer that their order has been accepted
+		if order.CustomerID != nil {
+			notifications = append(notifications, &models.Notification{
+				ID:        utils.GenerateUUID(),
+				UserID:    *order.CustomerID,
+				OrderID:   &order.ID,
+				Message:   "Your order has been accepted and is being prepared!",
+				IsRead:    false,
+				CreatedAt: time.Now(),
+			})
+		}
+
+	case models.RejectedByOwner:
+		// Notify customer that their order has been rejected
+		if order.CustomerID != nil {
+			notifications = append(notifications, &models.Notification{
+				ID:        utils.GenerateUUID(),
+				UserID:    *order.CustomerID,
+				OrderID:   &order.ID,
+				Message:   "Your order has been rejected. ",
+				IsRead:    false,
+				CreatedAt: time.Now(),
+			})
+		}
+
+	case models.ReadyForPickUp:
+		// Notify customer that their order is ready for pickup
+		if order.CustomerID != nil {
+			notifications = append(notifications, &models.Notification{
+				ID:        utils.GenerateUUID(),
+				UserID:    *order.CustomerID,
+				OrderID:   &order.ID,
+				Message:   "Your order is ready for pickup! A driver will be assigned soon.",
+				IsRead:    false,
+				CreatedAt: time.Now(),
+			})
+		}
+
+	case models.AcceptedByDriver:
+		// Notify customer that a driver has accepted their order
+		if order.CustomerID != nil {
+			notifications = append(notifications, &models.Notification{
+				ID:        utils.GenerateUUID(),
+				UserID:    *order.CustomerID,
+				OrderID:   &order.ID,
+				Message:   "A driver has accepted your order and is on the way!",
+				IsRead:    false,
+				CreatedAt: time.Now(),
+			})
+		}
+
+		// Notify restaurant owner that a driver has been assigned
+		restaurant, err := repo.GetRestaurantByID(order.RestaurantID)
+		if err == nil && restaurant.OwnerID != uuid.Nil {
+			notifications = append(notifications, &models.Notification{
+				ID:        utils.GenerateUUID(),
+				UserID:    restaurant.OwnerID,
+				OrderID:   &order.ID,
+				Message:   "A driver has been assigned to pick up the order.",
+				IsRead:    false,
+				CreatedAt: time.Now(),
+			})
+		}
+
+	case models.RejectedByDriver:
+		// Notify customer that no driver accepted their order
+		if order.CustomerID != nil {
+			notifications = append(notifications, &models.Notification{
+				ID:        utils.GenerateUUID(),
+				UserID:    *order.CustomerID,
+				OrderID:   &order.ID,
+				Message:   "No driver was available to deliver your order. We'll try to find another driver.",
+				IsRead:    false,
+				CreatedAt: time.Now(),
+			})
+		}
+
+		// Notify restaurant owner about driver rejection
+		restaurant, err := repo.GetRestaurantByID(order.RestaurantID)
+		if err == nil && restaurant.OwnerID != uuid.Nil {
+			notifications = append(notifications, &models.Notification{
+				ID:        utils.GenerateUUID(),
+				UserID:    restaurant.OwnerID,
+				OrderID:   &order.ID,
+				Message:   "No driver accepted the order. It's back in the queue.",
+				IsRead:    false,
+				CreatedAt: time.Now(),
+			})
+		}
+
+	case models.Assigned:
+		// Notify customer that their order has been assigned to a driver
+		if order.CustomerID != nil {
+			notifications = append(notifications, &models.Notification{
+				ID:        utils.GenerateUUID(),
+				UserID:    *order.CustomerID,
+				OrderID:   &order.ID,
+				Message:   "Your order has been assigned to a driver and is being picked up!",
+				IsRead:    false,
+				CreatedAt: time.Now(),
+			})
+		}
+
+	case models.InTransit:
+		// Notify customer that their order is on the way
+		if order.CustomerID != nil {
+			notifications = append(notifications, &models.Notification{
+				ID:        utils.GenerateUUID(),
+				UserID:    *order.CustomerID,
+				OrderID:   &order.ID,
+				Message:   "Your order is on the way! The driver is heading to your location.",
+				IsRead:    false,
+				CreatedAt: time.Now(),
+			})
+		}
+
+	case models.Delivered:
+		// Notify customer that their order has been delivered
+		if order.CustomerID != nil {
+			notifications = append(notifications, &models.Notification{
+				ID:        utils.GenerateUUID(),
+				UserID:    *order.CustomerID,
+				OrderID:   &order.ID,
+				Message:   "Your order has been delivered! Enjoy your meal!",
+				IsRead:    false,
+				CreatedAt: time.Now(),
+			})
+
+		}
+
+		// Notify restaurant owner that the order has been delivered
+		restaurant, err := repo.GetRestaurantByID(order.RestaurantID)
+		if err == nil && restaurant.OwnerID != uuid.Nil {
+			notifications = append(notifications, &models.Notification{
+				ID:        utils.GenerateUUID(),
+				UserID:    restaurant.OwnerID,
+				OrderID:   &order.ID,
+				Message:   "Order has been successfully delivered to the customer.",
+				IsRead:    false,
+				CreatedAt: time.Now(),
+			})
+		}
+
+	case models.Canceled:
+		// Notify restaurant owner that the order has been canceled
+		restaurant, err := repo.GetRestaurantByID(order.RestaurantID)
+		if err == nil && restaurant.OwnerID != uuid.Nil {
+			notifications = append(notifications, &models.Notification{
+				ID:        utils.GenerateUUID(),
+				UserID:    restaurant.OwnerID,
+				OrderID:   &order.ID,
+				Message:   "Order has been canceled by the customer.",
+				IsRead:    false,
+				CreatedAt: time.Now(),
+			})
+		}
+
+	}
+
+	for _, notification := range notifications {
+		if err := repo.CreateNotification(notification); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/utils/order_status.go
+++ b/pkg/utils/order_status.go
@@ -1,0 +1,18 @@
+package utils
+
+import "food-delivery-app-server/models"
+
+func IsValidOrderStatusTransition(currStatus, newStatus models.Status) bool {
+	switch currStatus {
+	case models.ReadyForPickUp:
+		return newStatus == models.AcceptedByDriver || newStatus == models.RejectedByDriver
+	case models.AcceptedByDriver:
+		return newStatus == models.InTransit
+	case models.InTransit:
+		return newStatus == models.Delivered
+	case models.Delivered:
+		return false
+	}
+
+	return false
+}


### PR DESCRIPTION
**Order Status Notification System**

- Added automatic notification creation on order status updates (accept, reject, ready, assigned, in transit, delivered, canceled).
- Introduced CreateStatusChangeNotifications utility in pkg/notifications/status.go to centralize notification logic
- Updated service layer (internal/order/service.go) to call the notification utility after status changes for both customer and driver actions
- Extended notification message length in models/notification.go for more descriptive updates
- Ensured both customers and restaurant owners receive relevant notifications for all major order status transitions